### PR TITLE
next_occurrence bug fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,3 +11,10 @@
 
 0.6.3
   * Change how active_support_occurs_on works
+  * Fixed bug where next_occurrence wouldn't work if no end_date was set
+
+0.6.4
+  * Fixed bug where next_occurrence wouldn't actually grab the correct next occurrence with
+    schedules that had more than one recurrence rule and/or a recurrence rule and a recurrence date
+  * Added next_occurrences function to schedule, allowing you to get the next N occurrences after a
+    given date

--- a/lib/ice_cube/rule_occurrence.rb
+++ b/lib/ice_cube/rule_occurrence.rb
@@ -27,13 +27,23 @@ module IceCube
 
     # Break after the first occurrence after now
     def next_occurrence(from)
-      found_one = false
-      find_occurrences do |roc| 
+      next_occurrences(1, from).first
+    end
+
+    # Break after the first n occurrences after now
+    def next_occurrences(n, from)
+      found_all = false
+      num_found = 0
+      nexts = find_occurrences do |roc|
         find = roc > from
-        success = found_one
-        found_one = find
+        num_found += 1 if find
+        success = found_all
+        found_all = num_found == n
         success
       end
+      #Since the above returns all up to and including the next N that were requested, we need
+      #to grab the last n, making sure to prune out ones that were actually before the from time
+      nexts.last(n).select{|occurrence| occurrence > from}
     end
 
     def first(n)

--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -135,8 +135,14 @@ module IceCube
     
     # Find next scheduled occurrence
     def next_occurrence(from = Time.now)
-      nexts = find_occurrences { |head| head.next_occurrence(from) }
-      nexts.empty? ? nil : (nexts.last if nexts.last > from)
+      next_occurrences(1, from).first
+    end
+
+    def next_occurrences(n, from = Time.now)
+      nexts = find_occurrences { |head| head.next_occurrences(n, from) }
+      #Grabs the first n occurrences after the from date, remembering that there is still a
+      #possibility that recurrence dates before the from time could be in the array
+      nexts.select{|occurrence| occurrence > from}.first(n)
     end
 
     # Retrieve the first (n) occurrences of the schedule.  May return less than

--- a/spec/examples/recur_spec.rb
+++ b/spec/examples/recur_spec.rb
@@ -38,4 +38,64 @@ describe Schedule, :next_occurrence do
     schedule.next_occurrence(schedule.start_time).should == schedule.start_time + 1.hour
   end
 
+  it 'should get the next occurrence when a recurrence date is also added' do
+    schedule = Schedule.new(Time.now)
+    schedule.add_recurrence_date(schedule.start_time + 30.minutes)
+    schedule.add_recurrence_rule Rule.hourly
+    schedule.next_occurrence(schedule.start_time).should == schedule.start_time + 30.minutes
+  end
+
+  it 'should get the next occurrence and ignore recurrence dates that are before the desired time' do
+    schedule = Schedule.new(Time.now)
+    schedule.add_recurrence_date(schedule.start_time + 30.minutes)
+    schedule.add_recurrence_date(schedule.start_time - 30.minutes)
+    schedule.add_recurrence_rule Rule.hourly
+    schedule.next_occurrence(schedule.start_time).should == schedule.start_time + 30.minutes
+  end
+
+end
+
+describe Schedule, :next_occurrences do
+
+  it 'should get the next 3 occurrence from now' do
+    schedule = Schedule.new(Time.now, :end_time => Time.now.end_of_day)
+    schedule.add_recurrence_rule(Rule.hourly)
+    schedule.next_occurrences(3).should == [schedule.start_time + 1.hour,
+      schedule.start_time + 2.hours,
+      schedule.start_time + 3.hours]
+  end
+
+  it 'should get the next 3 occurrence past the end of the year' do
+    schedule = Schedule.new(Time.now, :end_time => Time.now.end_of_day)
+    schedule.add_recurrence_rule(Rule.hourly)
+    schedule.next_occurrences(3, schedule.end_time + 1.year).should == []
+  end
+
+  it 'should be able to use next_occurrences on a never-ending schedule' do
+    schedule = Schedule.new(Time.now)
+    schedule.add_recurrence_rule Rule.hourly
+    schedule.next_occurrences(3, schedule.start_time).should == [schedule.start_time + 1.hour,
+      schedule.start_time + 2.hours,
+      schedule.start_time + 3.hours]
+  end
+
+  it 'should get the next 3 occurrences when a recurrence date is also added' do
+    schedule = Schedule.new(Time.now)
+    schedule.add_recurrence_rule Rule.hourly
+    schedule.add_recurrence_date(schedule.start_time + 30.minutes)
+    schedule.next_occurrences(3, schedule.start_time).should == [schedule.start_time + 30.minutes,
+      schedule.start_time + 1.hours,
+      schedule.start_time + 2.hours]
+  end
+
+  it 'should get the next 3 occurrences and ignore recurrence dates that are before the desired time' do
+    schedule = Schedule.new(Time.now)
+    schedule.add_recurrence_date(schedule.start_time + 30.minutes)
+    schedule.add_recurrence_date(schedule.start_time - 30.minutes)
+    schedule.add_recurrence_rule Rule.hourly
+    schedule.next_occurrences(3, schedule.start_time).should == [schedule.start_time + 30.minutes,
+      schedule.start_time + 1.hours,
+      schedule.start_time + 2.hours]
+  end
+
 end


### PR DESCRIPTION
John,

I fixed some bugs I noticed with the next_occurrence function related to more complex tests.  I have also been wanting to be able to (somewhat efficiently) get the next N occurrences from a given date, so, I added a next_occurrences function which allows for this.

Let me know what you think.  I also added a bit more to the changelog for 0.6.3 and gave a sample changelog comment for 0.6.4.

Case
