### PR TITLE
Until date format fix

### DIFF
--- a/lib/ice_cube/rule.rb
+++ b/lib/ice_cube/rule.rb
@@ -138,7 +138,7 @@ module IceCube
       representation
     end
     
-    #TODO - until date formatting is not iCalendar here
+    #TODO - until date formatting fixed but ice_cube doesn't store tz info for until dates
     #get the icalendar representation of this rule logic
     def to_ical_base
       representation = ''
@@ -147,7 +147,7 @@ module IceCube
         representation << ';' << v.send(:to_ical)
       end      
       representation << ";COUNT=#{@occurrence_count}" if @occurrence_count
-      representation << ";UNTIL=#{@until_date}" if @until_date
+      representation << ";UNTIL=#{@until_date.strftime("%Y%m%dT%H%M%SZ")}" if @until_date
       representation
     end
     


### PR DESCRIPTION
The rrule until date formatting is broken.  Right now ice_cube doesn't store time zone information for until dates so I've converted the until date to zulu date-time ical formatting.
