### PR TITLE
Added current date as start_date when called with nil parameter

### DIFF
--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -12,7 +12,7 @@ module IceCube
       @exrule_occurrence_heads = []
       @rdates = []
       @exdates = []
-      @start_date = start_date
+      @start_date = start_date || Time.now
       raise ArgumentError.new('Duration cannot be negative') if options[:duration] && options[:duration] < 0
       @duration = options[:duration]
       raise ArgumentError.new('Start time must be before end time') if options[:end_time] && options[:end_time] < @start_date

--- a/spec/examples/ice_cube_spec.rb
+++ b/spec/examples/ice_cube_spec.rb
@@ -737,5 +737,10 @@ describe IceCube::Schedule, 'occurs_on?' do
       date.sec.should == start_date_override.sec
     end
   end
+
+  it 'should use current date as start date when invoked with a nil parameter' do
+    schedule = IceCube::Schedule.new nil
+    schedule.start_date.strftime('%d.%m.%Y').should == Time.now.strftime('%d.%m.%Y')
+  end
 end
 


### PR DESCRIPTION
I'm using ice_cube with Schedule-Attributes, and for some reason SA appeared to initialize a schedule with a nil date.
Not sure if you want that default in ice_cube, but for us it's much easier than fixing our legacy systems. Please let me know if you don't want this change in ice_cube.
