### PR TITLE
Fix daily rule occurrences

### DIFF
--- a/lib/ice_cube/rules/daily_rule.rb
+++ b/lib/ice_cube/rules/daily_rule.rb
@@ -5,8 +5,8 @@ module IceCube
     # TODO repair
     # Determine whether this rule occurs on a give date.
     def in_interval?(date, start_date)
-      #make sure we're in a proper interval
-      day_count = date.yday - start_date.yday
+      #make sure we're in a proper interval      
+      day_count = date.to_date - start_date.to_date      
       day_count % @interval == 0
     end
 

--- a/spec/examples/daily_rule_spec.rb
+++ b/spec/examples/daily_rule_spec.rb
@@ -21,6 +21,16 @@ describe IceCube::DailyRule, 'occurs_on?' do
     dates.size.should == 3
     dates.should == [DAY, DAY + 2 * IceCube::ONE_DAY, DAY + 4 * IceCube::ONE_DAY]
   end
+  
+  it 'should produce the correct days for @interval = 2 when crossing into a new year' do
+    start_date = Date.parse('2011-12-29').to_time(:utc)
+    schedule = IceCube::Schedule.new(start_date)
+    schedule.add_recurrence_rule IceCube::Rule.daily(2)
+    #check assumption (3) -- (1) 2 (3) 4 (5) 6 
+    dates = schedule.occurrences(start_date + 5 * IceCube::ONE_DAY)
+    dates.size.should == 3
+    dates.should == [start_date, start_date + 2 * IceCube::ONE_DAY, start_date + 4 * IceCube::ONE_DAY]
+  end
 
   it 'should produce the correct days for interval of 4 day with hour and minute of day set' do
     start_date = DAY


### PR DESCRIPTION
Fixed daily rule so that occurrences can properly continue on into a new year. 

Previously #yday was being used in math operations but this caused issues because two odd yday numbers can occur back to back:

> > Date.parse('2011-12-31').yday
> > => 365
> > Date.parse('2012-1-1').yday
> > => 1

I also noticed a comment of "TODO repair" on line 5 of daily_rule.rb, I'm not sure of the purpose of the comment but you may want to remove it if my fix is the "repair".
