### PR TITLE
Proposed fix for https://github.com/seejohnrun/ice_cube/issues/29

### DIFF
--- a/lib/ice_cube/validations/day_of_week.rb
+++ b/lib/ice_cube/validations/day_of_week.rb
@@ -27,8 +27,15 @@ module IceCube
     def closest(date)
       return nil if !@days_of_week || @days_of_week.empty?
       goal = date
-      while goal += IceCube::ONE_DAY
-        return self.class.adjust(goal, date) if validate(goal)
+      while ( next_date = goal + IceCube::ONE_DAY )
+        # DST hack.  If our day starts at midnight, when DST ends it will be pushed to 11 PM on the previous day.
+        check_date = if next_date.day == goal.day
+                       next_date + IceCube::ONE_HOUR
+                     else
+                       next_date
+                     end
+        return self.class.adjust(next_date, date) if validate(check_date)
+        goal = next_date
       end
     end
 

--- a/spec/examples/weekly_rule_spec.rb
+++ b/spec/examples/weekly_rule_spec.rb
@@ -47,6 +47,24 @@ describe IceCube::WeeklyRule, 'occurs_on?' do
     end
   end
 
+  it 'should occur on every first monday of a month at midnight and not skip months when Daylights Savings Time ends' do
+    start_date = Time.local(2011, 8, 1)
+    schedule = IceCube::Schedule.new(start_date)
+    schedule.add_recurrence_rule IceCube::Rule.monthly.day_of_week(:monday => [1])
+    last_date = nil
+    schedule.first(100).each do |current_date|
+      current_date.wday.should == 1
+      if last_date then
+        month_interval = (current_date.year * 12 + current_date.month) - (last_date.year * 12 + last_date.month)
+        #puts "month_interval = #{month_interval}"
+        month_interval.should == 1
+      end
+      current_date.hour.should == 0
+      current_date.wday.should == 1
+      last_date = current_date
+    end
+  end
+
   it 'should be able to start on sunday but repeat on wednesdays' do
     schedule = IceCube::Schedule.new(Time.local(2010, 8, 1))
     schedule.add_recurrence_rule IceCube::Rule.weekly.day(:monday)


### PR DESCRIPTION
DST is causing us to lose a day for monthly schedules when moving out of DST for schedules that start at midnight.
This fixes it.  Also, added a test case to test for this issue.

This is my proposed fix for https://github.com/seejohnrun/ice_cube/issues/29
