### PR TITLE
This fixes month-skipping problems that my previous fix did not fully address.

### DIFF
--- a/lib/ice_cube/validations/day_of_week.rb
+++ b/lib/ice_cube/validations/day_of_week.rb
@@ -30,7 +30,11 @@ module IceCube
       while (next_date = goal + IceCube::ONE_DAY)
         # DST hack.  If our day starts at midnight, when DST ends it will be pushed to 11 PM on the previous day.
         check_date = next_date.day == goal.day ? next_date + IceCube::ONE_HOUR : next_date
-        return self.class.adjust(next_date, date) if validate(check_date)
+        if validate(check_date)
+          date_adj = self.class.adjust(next_date, date)
+          # Check date might have forced us to skip forward a day.
+          return date_adj.wday == check_date.wday ? date_adj : date_adj - IceCube::ONE_DAY
+        end
         goal = next_date
       end
     end

--- a/spec/examples/weekly_rule_spec.rb
+++ b/spec/examples/weekly_rule_spec.rb
@@ -46,22 +46,25 @@ describe IceCube::WeeklyRule, 'occurs_on?' do
       d.wday.should == 2
     end
   end
-
-  it 'should occur on every first monday of a month at midnight and not skip months when Daylights Savings Time ends' do
+  
+  it 'should occur on every first day of a month at midnight and not skip months when DST ends' do
     start_date = Time.local(2011, 8, 1)
-    schedule = IceCube::Schedule.new(start_date)
-    schedule.add_recurrence_rule IceCube::Rule.monthly.day_of_week(:monday => [1])
-    last_date = nil
-    schedule.first(100).each do |current_date|
-      current_date.wday.should == 1
-      if last_date then
-        month_interval = (current_date.year * 12 + current_date.month) - (last_date.year * 12 + last_date.month)
-        #puts "month_interval = #{month_interval}"
-        month_interval.should == 1
+    [:sunday, :monday, :tuesday, :wednesday, :thursday, :friday, :saturday].each_with_index do |day, index|
+      schedule = IceCube::Schedule.new(start_date)
+      schedule.add_recurrence_rule IceCube::Rule.monthly.day_of_week(day => [1])
+      last_date = nil
+      schedule.first(100).each do |current_date|
+        # should be the correct day of week
+        current_date.wday.should == index
+        # should be midnight
+        current_date.hour.should == 0
+        if last_date then
+          month_interval = (current_date.year * 12 + current_date.month) - (last_date.year * 12 + last_date.month)
+          # should not skip months
+          month_interval.should == 1
+        end
+        last_date = current_date
       end
-      current_date.hour.should == 0
-      current_date.wday.should == 1
-      last_date = current_date
     end
   end
 


### PR DESCRIPTION
My previous fix did not correctly handle situations where the DST switch happened more than a day
before the "closest" date match of the DayOfWeekValidation.

Basically, if DST cutover forced you an hour back, the check_date adjustment wouldn't happen after incrementing two or more days.

I fixed the unit test to correctly identify this situation.

``` ruby
  it 'should occur on every first day of a month at midnight and not skip months when DST ends' do
    start_date = Time.local(2011, 8, 1)
    [:sunday, :monday, :tuesday, :wednesday, :thursday, :friday, :saturday].each_with_index do |day, index|
      schedule = IceCube::Schedule.new(start_date)
      schedule.add_recurrence_rule IceCube::Rule.monthly.day_of_week(day => [1])
      last_date = nil
      schedule.first(100).each do |current_date|
        # should be the correct day of week
        current_date.wday.should == index
        # should be midnight
        current_date.hour.should == 0
        if last_date then
          month_interval = (current_date.year * 12 + current_date.month) - (last_date.year * 12 + last_date.month)
          # should not skip months
          month_interval.should == 1
        end
        last_date = current_date
      end
    end
  end
```
