### PR TITLE
Fixing an issue I was having on ruby 1.8.7 where the 'head' param was actually an array of [head, exclude_dates] 

### DIFF
--- a/lib/ice_cube/rule_occurrence.rb
+++ b/lib/ice_cube/rule_occurrence.rb
@@ -39,9 +39,19 @@ module IceCube
       nexts.last(n).select{|occurrence| occurrence > from}
     end
 
-    def first(n)
+    def first(n, exclude_dates)
+      rocs = []
       count = 0
-      find_occurrences { |roc| count += 1; count > n }
+      nexts = find_occurrences do |roc|
+        unless exclude_dates.include?(roc.to_time)
+          count += 1
+          rocs << roc
+        end
+
+        count > n
+      end
+
+      rocs
     end
 
     #get the next occurrence of this rule

--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -170,7 +170,7 @@ module IceCube
     # Retrieve the first (n) occurrences of the schedule.  May return less than
     # n results, if the rules end before n results are reached.
     def first(n = nil)
-      dates = find_occurrences { |head, exclude_dates| head.first(n || 1) }
+      dates = find_occurrences { |head, exclude_dates| head.first((n || 1), exclude_dates) }
       n.nil? ? dates.first : dates.slice(0, n)
     end
 


### PR DESCRIPTION
fixing bug on ruby 1.8.7 where the block parameter count is off and thus making the callback return an array of [rrule_occurrence_head, exclude_dates] instead of the rrule_occurrence_head. this was causing an error eventually in the code : NoMethodError (undefined method "upto" for #Array:ID)
