### PR TITLE
Added "Weekdays"

### DIFF
--- a/lib/ice_cube/validations/day.rb
+++ b/lib/ice_cube/validations/day.rb
@@ -28,7 +28,11 @@ module IceCube
   
     def to_s
       days_dup = (@days - @rule.validations[:day_of_week].keys if @rule.validations[:day_of_week]) || @days # don't list twice
-      'on ' << self.class.sentence(days_dup.map { |d| Date::DAYNAMES[d] + 's' }) unless days_dup.empty?
+      if days_dup.sort == [1,2,3,4,5]
+        'on all Weekdays'
+      elsif days_dup.present?
+        'on ' << self.class.sentence(days_dup.map { |d| Date::DAYNAMES[d] + 's' })
+      end
     end
 
     def to_ical

--- a/spec/examples/to_s_spec.rb
+++ b/spec/examples/to_s_spec.rb
@@ -42,6 +42,7 @@ describe IceCube::Schedule, 'to_s' do
     IceCube::Rule.weekly.day(:monday).to_s.should == 'Weekly on Mondays'
     IceCube::Rule.weekly.day(:monday, :tuesday).to_s.should == 'Weekly on Mondays and Tuesdays'
     IceCube::Rule.weekly.day(:monday, :tuesday, :wednesday).to_s.should == 'Weekly on Mondays, Tuesdays, and Wednesdays'
+    IceCube::Rule.weekly.day(:monday, :tuesday, :wednesday, :thursday, :friday).to_s.should == 'Weekly on Weekdays'
   end
 
   it 'should work with a single date' do


### PR DESCRIPTION
I'm using your excellent gem in an app which often has all weekdays selected. I wanted to clean it up by having it say "weekdays" instead of listing each day separately.

Thanks for the great tool!
