### PR TITLE
Schedule#to_s does not work when an end_time is set

### DIFF
--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -199,7 +199,7 @@ module IceCube
       pieces.concat rrules.map { |t| t.to_s }
       pieces.concat exrules.map { |t| "not #{t.to_s}" }
       pieces.concat ed.sort.map { |t| "not on #{t.strftime(TO_S_TIME_FORMAT)}" }
-      pieces << "until #{end_time.strftime(TIME_FORMAT)}" if end_time
+      pieces << "until #{end_time.strftime(TO_S_TIME_FORMAT)}" if end_time
       pieces.join(' / ')
     end
 

--- a/spec/examples/to_s_spec.rb
+++ b/spec/examples/to_s_spec.rb
@@ -151,4 +151,10 @@ describe IceCube::Schedule, 'to_s' do
     schedule.to_s.should == 'Weekly 2 times'
   end
 
+  it 'should work when an end_time is set' do
+    schedule = IceCube::Schedule.new(Time.local(2012, 8, 31), :end_time => Time.local(2012, 10, 31))
+    schedule.add_recurrence_rule IceCube::Rule.daily.count(2)
+    schedule.to_s.should == 'Daily 2 times / until October 31, 2012'
+  end
+
 end


### PR DESCRIPTION
It seems a constant called TIME_FORMATS was renamed to TO_S_TIME_FORMATS but was missed in this one line.
