### PR TITLE
Dump & load class methods on IceCube::Schedule

### DIFF
--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -318,6 +318,14 @@ module IceCube
       end_time || recurrence_rules.all?(&:terminating?)
     end
 
+    def self.dump(schedule)
+      schedule.to_yaml
+    end
+
+    def self.load(yaml)
+      from_yaml(yaml) unless yaml.nil? || yaml.empty?
+    end
+
     private
 
     # Reset all rules for another run

--- a/spec/examples/serialization_spec.rb
+++ b/spec/examples/serialization_spec.rb
@@ -1,0 +1,30 @@
+require 'active_support/time'
+require File.dirname(__FILE__) + '/../spec_helper'
+
+describe IceCube::Schedule do
+  let(:schedule) { IceCube::Schedule.new Time.now }
+  let(:yaml)     { described_class.dump(schedule) }
+
+  describe '::dump(schedule)' do
+    it 'serializes a Schedule object as YAML string' do
+      yaml.should be_a_kind_of String
+    end
+  end
+
+  describe '::load(yaml)' do
+    let(:new_schedule) { described_class.load yaml }
+
+    it 'creates a new object from a YAML string' do
+      new_schedule.start_time.should eq schedule.start_time
+    end
+
+    context 'when yaml is blank' do
+      let(:yaml) { nil }
+
+      it 'returns nil' do
+        new_schedule.should be_nil
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Just added those two methods to easily (and properly) serialize in ActiveRecord.
