### PR TITLE
Use TimeUtil.serialize_time for end_time.

### DIFF
--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -274,7 +274,7 @@ module IceCube
     def to_hash
       data = {}
       data[:start_date] = TimeUtil.serialize_time(start_time)
-      data[:end_time] = end_time if end_time
+      data[:end_time] = TimeUtil.serialize_time(end_time) if end_time
       data[:duration] = duration if duration
       data[:rrules] = recurrence_rules.map(&:to_hash)
       data[:exrules] = exception_rules.map(&:to_hash)


### PR DESCRIPTION
Currently, it doesn’t serialize correctly ActiveSupport Times. (only for end_time)
