### PR TITLE
Schedule find_occurrence when interval is greater than 1 won't use the start date causing invalid results

### DIFF
--- a/lib/ice_cube/rule.rb
+++ b/lib/ice_cube/rule.rb
@@ -70,7 +70,7 @@ module IceCube
 
     # Whether this rule requires a full run
     def full_required?
-      !@count.nil?
+      !@count.nil? || (! @interval.nil? && @interval > 1)
     end
 
     # Convenience methods for creating Rules

--- a/lib/ice_cube/validations/daily_interval.rb
+++ b/lib/ice_cube/validations/daily_interval.rb
@@ -4,6 +4,7 @@ module IceCube
 
     # Add a new interval validation
     def interval(interval)
+      @interval = interval
       validations_for(:interval) << Validation.new(interval)
       clobber_base_validations(:wday, :day)
       self

--- a/lib/ice_cube/validations/monthly_interval.rb
+++ b/lib/ice_cube/validations/monthly_interval.rb
@@ -3,6 +3,7 @@ module IceCube
   module Validations::MonthlyInterval
 
     def interval(interval = 1)
+      @interval = interval
       validations_for(:interval) << Validation.new(interval)
       clobber_base_validations(:month)
       self

--- a/lib/ice_cube/validations/weekly_interval.rb
+++ b/lib/ice_cube/validations/weekly_interval.rb
@@ -5,6 +5,7 @@ module IceCube
   module Validations::WeeklyInterval
 
     def interval(interval, week_start = :sunday)
+      @interval = interval
       validations_for(:interval) << Validation.new(interval, week_start)
       clobber_base_validations(:day)
       self

--- a/lib/ice_cube/validations/yearly_interval.rb
+++ b/lib/ice_cube/validations/yearly_interval.rb
@@ -3,6 +3,7 @@ module IceCube
   module Validations::YearlyInterval
 
     def interval(interval = 1)
+      @interval = interval
       validations_for(:interval) << Validation.new(interval)
       clobber_base_validations(:year)
     end

--- a/spec/examples/daily_rule_spec.rb
+++ b/spec/examples/daily_rule_spec.rb
@@ -45,4 +45,16 @@ describe IceCube::DailyRule, 'occurs_on?' do
     ]
   end
 
+  context "full_required?" do
+    it "should return true when interval is > 1" do
+      rule = IceCube::Rule.daily(2)
+      rule.full_required?.should be_true
+    end
+
+    it "should return false when interval is <= 1" do
+      rule = IceCube::Rule.daily
+      rule.full_required?.should be_false
+    end
+  end
+
 end

--- a/spec/examples/ice_cube_spec.rb
+++ b/spec/examples/ice_cube_spec.rb
@@ -337,6 +337,16 @@ describe IceCube::Schedule, 'occurs_on?' do
     dates.should == [start_time + IceCube::ONE_DAY * 2, start_time + IceCube::ONE_DAY * 3, start_time + IceCube::ONE_DAY * 4]
   end
 
+  it 'should use start date on a bi-weekly recurrence pattern to find the occurrences_between when interval > 1' do
+    start_date = Time.local(2011, 3, 20)
+
+    schedule = IceCube::Schedule.new(start_date)
+    schedule.add_recurrence_rule IceCube::Rule.weekly(2).day(:sunday)
+
+    occurrences = schedule.occurrences_between(Time.local(2012, 7, 7), Time.local(2012, 7, 9))
+    occurrences.should == [Time.local(2012, 7, 8)]
+  end
+
   it 'should be able to tell us when there is at least one occurrence between two dates' do
     start_date = WEDNESDAY
     schedule = IceCube::Schedule.new(start_date)
@@ -778,6 +788,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     rule = IceCube::Rule.daily.count(5)
     rule.occurrence_count.should == 5
   end
+
 
 end
 

--- a/spec/examples/monthly_rule_spec.rb
+++ b/spec/examples/monthly_rule_spec.rb
@@ -57,5 +57,17 @@ describe IceCube::MonthlyRule, 'occurs_on?' do
     #check assumption (12 months - 2 dates each)
     schedule.occurrences(end_date).size.should == 24
   end
+
+  context "full_required?" do
+    it "should return true when interval is > 1" do
+      rule = IceCube::Rule.monthly(2)
+      rule.full_required?.should be_true
+    end
+
+    it "should return false when interval is <= 1" do
+      rule = IceCube::Rule.monthly
+      rule.full_required?.should be_false
+    end
+  end
     
 end

--- a/spec/examples/weekly_rule_spec.rb
+++ b/spec/examples/weekly_rule_spec.rb
@@ -86,4 +86,16 @@ describe IceCube::WeeklyRule, 'occurs_on?' do
     schedule.first(3).should == [Time.local(2012,2,7), Time.local(2012,2,19), Time.local(2012,2,21)]
   end
 
+  context "full_required?" do
+    it "should return true when interval is > 1" do
+      rule = IceCube::Rule.weekly(2).day(:sunday)
+      rule.full_required?.should be_true
+    end
+
+    it "should return false when interval is <= 1" do
+      rule = IceCube::Rule.weekly.day(:sunday)
+      rule.full_required?.should be_false
+    end
+  end
+
 end

--- a/spec/examples/yearly_rule_spec.rb
+++ b/spec/examples/yearly_rule_spec.rb
@@ -48,5 +48,16 @@ describe IceCube::YearlyRule, 'occurs_on?' do
     #check assumption
     schedule.occurrences(Time.utc(2010, 12, 31)).size.should == 2
   end
-  
+
+  context "full_required?" do
+    it "should return true when interval is > 1" do
+      rule = IceCube::Rule.yearly(2)
+      rule.full_required?.should be_true
+    end
+
+    it "should return false when interval is <= 1" do
+      rule = IceCube::Rule.yearly
+      rule.full_required?.should be_false
+    end
+  end
 end


### PR DESCRIPTION
I found when the `find_occurrences` function is called in `Schedule` that it wants to start from the `opening_time` when looping to find the occurrences between the `begin_time` and `end_time` when the interval is greater than 1. When the interval is > 1 I believe it should begin looping at the `start_time` to make sure when it gets to the `opening_time` and the `closing_time` that it knows that the occurrence falls in the range.

I added `@interval` in daily_interval.rb, weekly_interval.rb, monthly_interval.rb, and yearly_interval.rb to allow `Rule` to have access to it. Then I altered the `full_required?` method to check the interval and make sure it exists and if > 1 to return true.

``` ruby
# Whether this rule requires a full run
def full_required?
  !@count.nil? || (! @interval.nil? && @interval > 1)
end
```
