### PR TITLE
use UNTIL instead of DTEND to determine last instance of recurrence; fixes #99

### DIFF
--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -315,7 +315,7 @@ module IceCube
     # Determine if the schedule will end
     # @return [Boolean] true if ending, false if repeating forever
     def terminating?
-      end_time || recurrence_rules.all?(&:terminating?)
+      recurrence_rules.empty? || recurrence_rules.all?(&:terminating?)
     end
 
     def self.dump(schedule)
@@ -339,10 +339,6 @@ module IceCube
     def find_occurrences(opening_time, closing_time = nil, limit = nil, &block)
       reset
       answers = []
-      # ensure the bounds are proper
-      if end_time
-        closing_time = end_time unless closing_time && closing_time < end_time
-      end
       opening_time = start_time if opening_time < start_time
       # walk up to the opening time - and off we go
       # If we have rules with counts, we need to walk from the beginning of time,

--- a/spec/examples/ice_cube_spec.rb
+++ b/spec/examples/ice_cube_spec.rb
@@ -465,8 +465,9 @@ describe IceCube::Schedule, 'occurs_on?' do
 
   it 'should be able to specify an end time for the schedule' do
     start_time = DAY
-    schedule = IceCube::Schedule.new(start_time, :end_time => DAY + IceCube::ONE_DAY * 2)
-    schedule.add_recurrence_rule IceCube::Rule.daily
+    end_time = DAY + IceCube::ONE_DAY * 2
+    schedule = IceCube::Schedule.new(start_time)
+    schedule.add_recurrence_rule IceCube::Rule.daily.until(end_time)
     schedule.all_occurrences.should == [DAY, DAY + 1*IceCube::ONE_DAY, DAY + 2*IceCube::ONE_DAY]
   end
 
@@ -477,8 +478,8 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule.add_recurrence_rule IceCube::Rule.daily
     schedule.first(5).should == [DAY, DAY + 1*IceCube::ONE_DAY, DAY + 2*IceCube::ONE_DAY, DAY + 3*IceCube::ONE_DAY, DAY + 4*IceCube::ONE_DAY]
     # and then ensure that with the end time it stops it at the right day
-    schedule = IceCube::Schedule.new(start_time, :end_time => DAY + IceCube::ONE_DAY * 2 + 1)
-    schedule.add_recurrence_rule IceCube::Rule.daily
+    schedule = IceCube::Schedule.new(start_time)
+    schedule.add_recurrence_rule IceCube::Rule.daily.until(DAY + IceCube::ONE_DAY * 2 + 1)
     schedule.first(5).should == [DAY, DAY + 1 * IceCube::ONE_DAY, DAY + 2 * IceCube::ONE_DAY]
   end
 
@@ -494,8 +495,8 @@ describe IceCube::Schedule, 'occurs_on?' do
   it 'should be able to specify an end date for the schedule and only get those on .occurrences_between' do
     start_time = DAY
     end_time = DAY + IceCube::ONE_DAY * 2
-    schedule = IceCube::Schedule.new(start_time, :end_time => end_time)
-    schedule.add_recurrence_rule IceCube::Rule.daily
+    schedule = IceCube::Schedule.new(start_time)
+    schedule.add_recurrence_rule IceCube::Rule.daily.until(end_time)
     expectation = [DAY, DAY + IceCube::ONE_DAY, DAY + 2*IceCube::ONE_DAY]
     schedule.occurrences_between(start_time - IceCube::ONE_DAY, start_time + 4 * IceCube::ONE_DAY).should == expectation
   end
@@ -503,8 +504,8 @@ describe IceCube::Schedule, 'occurs_on?' do
   it 'should be able to specify an end date for the schedule and only get those on .occurrences' do
     start_time = DAY
     end_time = DAY + IceCube::ONE_DAY * 2
-    schedule = IceCube::Schedule.new(start_time, :end_time => end_time)
-    schedule.add_recurrence_rule IceCube::Rule.daily
+    schedule = IceCube::Schedule.new(start_time)
+    schedule.add_recurrence_rule IceCube::Rule.daily.until(end_time)
     expectation = [DAY, DAY + IceCube::ONE_DAY, DAY + 2*IceCube::ONE_DAY]
     schedule.occurrences(start_time + 4 * IceCube::ONE_DAY).should == expectation
   end
@@ -512,24 +513,24 @@ describe IceCube::Schedule, 'occurs_on?' do
   it 'should be able to work with an end date and .occurs_at' do
     start_time = DAY
     end_time = DAY + IceCube::ONE_DAY * 2
-    schedule = IceCube::Schedule.new(start_time, :end_time => end_time)
-    schedule.add_recurrence_rule IceCube::Rule.daily
+    schedule = IceCube::Schedule.new(start_time)
+    schedule.add_recurrence_rule IceCube::Rule.daily.until(end_time)
     schedule.occurs_at?(DAY + 4*IceCube::ONE_DAY).should be(false) # out of range
   end
 
   it 'should be able to work with an end date and .occurs_at' do
     start_time = DAY
     end_time = DAY + IceCube::ONE_DAY * 2
-    schedule = IceCube::Schedule.new(start_time, :end_time => end_time)
-    schedule.add_recurrence_rule IceCube::Rule.daily
+    schedule = IceCube::Schedule.new(start_time)
+    schedule.add_recurrence_rule IceCube::Rule.daily.until(end_time)
     schedule.occurs_on?((DAY + 4*IceCube::ONE_DAY)).should be(false) # out of range
   end
 
   it 'should be able to work with an end date and .occurring_at' do
     start_time = DAY
     end_time = DAY + IceCube::ONE_DAY * 2
-    schedule = IceCube::Schedule.new(start_time, :end_time => end_time, :duration => 20)
-    schedule.add_recurrence_rule IceCube::Rule.daily
+    schedule = IceCube::Schedule.new(start_time, :duration => 20)
+    schedule.add_recurrence_rule IceCube::Rule.daily.until(end_time)
     schedule.occurring_at?((DAY + 2*IceCube::ONE_DAY + 10)).should be(true) # in range
     schedule.occurring_at?((DAY + 4*IceCube::ONE_DAY + 10)).should be(false) # out of range
   end
@@ -583,8 +584,8 @@ describe IceCube::Schedule, 'occurs_on?' do
   end
 
   it 'should be able to know when to stop with an end date and a rule that misses a few times' do
-    schedule = IceCube::Schedule.new(Time.local(2010, 2, 29), :end_time => Time.local(2010, 10, 30))
-    schedule.add_recurrence_rule IceCube::Rule.yearly
+    schedule = IceCube::Schedule.new(Time.local(2010, 2, 29))
+    schedule.add_recurrence_rule IceCube::Rule.yearly.until(Time.local(2010, 10, 30))
     schedule.first(10).should == [Time.local(2010, 2, 29)]
   end
 
@@ -601,23 +602,23 @@ describe IceCube::Schedule, 'occurs_on?' do
   end
 
   it 'should be able to go through a year of every month on a day that does not exist' do
-    schedule = IceCube::Schedule.new(Time.zone.local(2010, 1, 31), :end_time => Time.zone.local(2011, 2, 5))
-    schedule.add_recurrence_rule IceCube::Rule.monthly
+    schedule = IceCube::Schedule.new(Time.zone.local(2010, 1, 31))
+    schedule.add_recurrence_rule IceCube::Rule.monthly.until(Time.zone.local(2011, 2, 5))
     schedule.all_occurrences.should == [Time.zone.local(2010, 1, 31), Time.zone.local(2010, 3, 31), Time.zone.local(2010, 5, 31),
                                  Time.zone.local(2010, 7, 31), Time.zone.local(2010, 8, 31), Time.zone.local(2010, 10, 31),
                                  Time.zone.local(2010, 12, 31), Time.zone.local(2011, 1, 31)]
   end
 
   it 'should be able to go through a year of every 2 months on a day that does not exist' do
-    schedule = IceCube::Schedule.new(Time.zone.local(2010, 1, 31), :end_time => Time.zone.local(2011, 2, 5))
-    schedule.add_recurrence_rule IceCube::Rule.monthly(2)
+    schedule = IceCube::Schedule.new(Time.zone.local(2010, 1, 31))
+    schedule.add_recurrence_rule IceCube::Rule.monthly(2).until(Time.zone.local(2011, 2, 5))
     schedule.all_occurrences.should == [Time.zone.local(2010, 1, 31), Time.zone.local(2010, 3, 31), Time.zone.local(2010, 5, 31),
                                         Time.zone.local(2010, 7, 31), Time.zone.local(2011, 1, 31)]
   end
 
   it 'should be able to go through a year of every 3 months on a day that does not exist' do
-    schedule = IceCube::Schedule.new(Time.local(2010, 1, 31), :end_time => Time.local(2011, 2, 5))
-    schedule.add_recurrence_rule IceCube::Rule.monthly(3)
+    schedule = IceCube::Schedule.new(Time.local(2010, 1, 31))
+    schedule.add_recurrence_rule IceCube::Rule.monthly(3).until(Time.local(2011, 2, 5))
     schedule.all_occurrences.should == [Time.local(2010, 1, 31), Time.local(2010, 7, 31), Time.local(2010, 10, 31), Time.local(2011, 1, 31)]
   end
 

--- a/spec/examples/recur_spec.rb
+++ b/spec/examples/recur_spec.rb
@@ -6,16 +6,17 @@ describe :remaining_occurrences do
 
   it 'should get the proper remaining occurrences from now' do
     start_time = Time.now
-    schedule = Schedule.new(start_time, :end_time => Time.local(start_time.year, start_time.month, start_time.day, 23, 59, 59))
-    schedule.add_recurrence_rule(Rule.hourly)
+    end_time = Time.local(start_time.year, start_time.month, start_time.day, 23, 59, 59)
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule(Rule.hourly.until(end_time))
     schedule.remaining_occurrences(start_time).size.should == 24 - schedule.start_time.hour
   end
 
   it 'should get the proper ramining occurrences past the end of the year' do
     start_time = Time.now
-    schedule = Schedule.new(start_time, :end_time => start_time + ONE_DAY)
-    schedule.add_recurrence_rule(Rule.hourly)
-    schedule.remaining_occurrences(schedule.end_time + 366 * ONE_DAY).size.should == 0
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule(Rule.hourly.until(start_time + ONE_DAY))
+    schedule.remaining_occurrences(start_time + 366 * ONE_DAY).size.should == 0
   end
 
 end
@@ -32,7 +33,7 @@ describe :next_occurrence do
   it 'should get the next occurrence past the end of the year' do
     schedule = Schedule.new(Time.now, :end_time => Time.now + 24 * ONE_HOUR)
     schedule.add_recurrence_rule(Rule.hourly)
-    schedule.next_occurrence(schedule.end_time + 366 * ONE_DAY).should == nil
+    schedule.next_occurrence(schedule.end_time + 366 * ONE_DAY).should == schedule.end_time + 366 * ONE_DAY + 1 * ONE_HOUR
   end
 
   it 'should be able to use next_occurrence on a never-ending schedule' do
@@ -72,7 +73,7 @@ describe :next_occurrences do
 
   it 'should get the next 3 occurrence past the end of the year' do
     schedule = Schedule.new(Time.now, :end_time => Time.now + ONE_HOUR * 24)
-    schedule.add_recurrence_rule(Rule.hourly)
+    schedule.add_recurrence_rule(Rule.hourly.until(Time.now + 365 * ONE_DAY))
     schedule.next_occurrences(3, schedule.end_time + 366 * ONE_DAY).should == []
   end
 

--- a/spec/examples/regression_spec.rb
+++ b/spec/examples/regression_spec.rb
@@ -56,9 +56,9 @@ describe IceCube do
   end
 
   it 'should handle a simple weekly schedule - icecube issue #52' do
-    rule_inst = IceCube::Rule.weekly(1).day(4)
     st = Time.new(2011, 12, 1, 18, 0, 0)
     fin = Time.new(2012, 1, 1, 18, 0, 0)
+    rule_inst = IceCube::Rule.weekly(1).day(4).until(fin)
     schedule = IceCube::Schedule.new(st, :end_time => fin)
     schedule.add_recurrence_rule rule_inst
     schedule.all_occurrences.should == [

--- a/spec/examples/to_yaml_spec.rb
+++ b/spec/examples/to_yaml_spec.rb
@@ -148,7 +148,7 @@ describe IceCube::Schedule, 'to_yaml' do
     start_date = Time.zone.local(2011, 11, 5, 12, 0, 0)
     schedule = IceCube::Schedule.new(start_date)
     schedule = IceCube::Schedule.from_yaml(schedule.to_yaml) # round trip
-    ice_cube_start_date = schedule.start_date
+    ice_cube_start_date = schedule.start_time
     ice_cube_start_date.should == start_date
     ice_cube_start_date.utc_offset.should == start_date.utc_offset
   end
@@ -157,7 +157,7 @@ describe IceCube::Schedule, 'to_yaml' do
     start_date = Time.now
     schedule = IceCube::Schedule.new(start_date)
     schedule = IceCube::Schedule.from_yaml(schedule.to_yaml) # round trip
-    ice_cube_start_date = schedule.start_date
+    ice_cube_start_date = schedule.start_time
     ice_cube_start_date.to_s.should == start_date.to_s
     ice_cube_start_date.class.should == Time
     ice_cube_start_date.utc_offset.should == start_date.utc_offset
@@ -229,19 +229,19 @@ describe IceCube::Schedule, 'to_yaml' do
     Time.zone = pacific_time
     schedule = IceCube::Schedule.new(Time.zone.now)
     schedule.add_recurrence_rule IceCube::Rule.weekly
-    schedule.occurs_on?(schedule.start_date.to_date + 6).should be(false)
-    schedule.occurs_on?(schedule.start_date.to_date + 7).should be(true)
-    schedule.occurs_on?(schedule.start_date.to_date + 8).should be(false)
+    schedule.occurs_on?(schedule.start_time.to_date + 6).should be(false)
+    schedule.occurs_on?(schedule.start_time.to_date + 7).should be(true)
+    schedule.occurs_on?(schedule.start_time.to_date + 8).should be(false)
   end
 
   it 'should work with occurs_on and TimeWithZone' do
     pacific_time = 'Pacific Time (US & Canada)'
     Time.zone = pacific_time
     schedule = IceCube::Schedule.new(Time.zone.now)
-    schedule.add_recurrence_date Time.zone.now + 7 * IceCube::ONE_DAY
-    schedule.occurs_on?(schedule.start_date.to_date + 6).should be(false)
-    schedule.occurs_on?(schedule.start_date.to_date + 7).should be(true)
-    schedule.occurs_on?(schedule.start_date.to_date + 8).should be(false)
+    schedule.add_recurrence_time Time.zone.now + 7 * IceCube::ONE_DAY
+    schedule.occurs_on?(schedule.start_time.to_date + 6).should be(false)
+    schedule.occurs_on?(schedule.start_time.to_date + 7).should be(true)
+    schedule.occurs_on?(schedule.start_time.to_date + 8).should be(false)
   end
 
   it 'should crazy patch' do


### PR DESCRIPTION
I believe this better conforms to the RFC. The tests that depended on the non-conforming behavior had to be modified to pass.
