### PR TITLE
Remove validation when rule until is set to nil

### DIFF
--- a/lib/ice_cube/validations/until.rb
+++ b/lib/ice_cube/validations/until.rb
@@ -12,7 +12,7 @@ module IceCube
 
     def until(time)
       @until = time
-      replace_validations_for(:until, [Validation.new(time)])
+      replace_validations_for(:until, time.nil? ? nil : [Validation.new(time)])
       self
     end
 

--- a/spec/examples/ice_cube_spec.rb
+++ b/spec/examples/ice_cube_spec.rb
@@ -808,7 +808,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     rule = IceCube::Rule.daily.until(Time.now + IceCube::ONE_DAY)
     rule.to_hash[:until].should_not be_nil
     rule.until nil
-    rule.to_hash[:until].should be_nil
+    rule.to_hash.should_not have_key(:until)
   end
 
   # Full required for rules account for @interval

--- a/spec/examples/regression_spec.rb
+++ b/spec/examples/regression_spec.rb
@@ -114,7 +114,7 @@ describe IceCube do
   it 'should return true if a recurring schedule occurs_between? a time range [#88]' do
     start_time = Time.new(2012, 7, 7, 8)
     schedule = IceCube::Schedule.new(start_time, :duration => 2 * IceCube::ONE_HOUR)
-    schedule.add_recurrence_rule Rule.weekly
+    schedule.add_recurrence_rule IceCube::Rule.weekly
     t1 = Time.new(2012, 7, 14, 9)
     t2 = Time.new(2012, 7, 14, 11)
     schedule.occurring_between?(t1, t2).should be_true
@@ -175,6 +175,18 @@ describe IceCube do
       schedule.add_exception_time ex
     end
     schedule.first.should == Time.zone.local(2011, 12, 29, 14)
+  end
+
+  it 'should not raise an exception after setting the rule until to nil' do
+    rule = IceCube::Rule.daily.until(Time.local(2012, 10, 1))
+    rule.until(nil)
+
+    schedule = IceCube::Schedule.new Time.local(2011, 10, 11, 12)
+    schedule.add_recurrence_rule rule
+
+    lambda {
+      schedule.occurrences_between(Time.local(2012, 1, 1), Time.local(2012, 12, 1))
+    }.should_not raise_error(ArgumentError, 'comparison of Time with nil failed')
   end
 
 end


### PR DESCRIPTION
When changing the until time for a rule to "nil" and then calling for example "occurrences_between" I get a nil comparison exception.

Please see the specs for more information.
