### PR TITLE
Validations based on Orthodox Pascha

### DIFF
--- a/lib/ice_cube.rb
+++ b/lib/ice_cube.rb
@@ -60,6 +60,8 @@ module IceCube
     autoload :DayOfWeek, 'ice_cube/validations/day_of_week'
     autoload :Day, 'ice_cube/validations/day'
     autoload :DayOfYear, 'ice_cube/validations/day_of_year'
+    
+    autoload :OffsetFromPascha, 'ice_cube/validations/offset_from_pascha'
 
   end
 

--- a/lib/ice_cube/time_util.rb
+++ b/lib/ice_cube/time_util.rb
@@ -170,6 +170,17 @@ module IceCube
     def self.is_leap?(year)
       (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
     end
+    
+    
+    def self.date_of_pascha(year)
+      g = year % 19
+      i = (19 * g + 15) % 30
+      j = (year + year/4 + i) % 7
+      l = i - j
+      month = 3 + (l + 40) / 44
+      day = l + 28 - 31 * (month / 4)
+      Date::civil(year, month, day, Date::JULIAN).gregorian
+    end
 
     # A utility class for safely moving time around
     class TimeWrapper

--- a/lib/ice_cube/validated_rule.rb
+++ b/lib/ice_cube/validated_rule.rb
@@ -12,6 +12,9 @@ module IceCube
     include Validations::Day
     include Validations::MonthOfYear
     include Validations::DayOfYear
+    
+    include Validations::OffsetFromPascha
+    
 
     include Validations::Count
     include Validations::Until

--- a/lib/ice_cube/validations/offset_from_pascha.rb
+++ b/lib/ice_cube/validations/offset_from_pascha.rb
@@ -1,0 +1,60 @@
+module IceCube
+
+  module Validations::OffsetFromPascha
+
+    def offset_from_pascha(offset)
+
+      validations_for(:offset_from_pascha) << Validation.new(offset)
+
+      clobber_base_validations(:month, :day, :wday)
+      self
+    end
+
+    class Validation
+
+      attr_reader :offset
+
+      StringBuilder.register_formatter(:offset_from_pascha) do |entries|
+        str = "#{StringBuilder.sentence(entries)} days "
+        str << (entries.first > 0 ? "after" : "before")
+        #str << "after"
+        str << " Pascha"
+        str
+      end
+
+      def initialize(offset)
+        @offset = offset
+      end
+
+      def type
+        :day
+      end
+
+      def build_s(builder)
+        builder.piece(:offset_from_pascha) << offset#StringBuilder.nice_number(offset)
+      end
+
+      def build_hash(builder)
+        builder.validations_array(:offset_from_pascha) << offset
+      end
+
+      def build_ical(builder)
+        #builder['BYYEARDAY'] << day
+      end
+
+      def validate(time, schedule)
+        pascha = TimeUtil.date_of_pascha(time.year)
+        if pascha + offset < time.to_date
+          pascha = TimeUtil.date_of_pascha(time.year + 1) 
+        end
+        the_day = pascha + offset
+        # compute the diff
+        diff = the_day - time.to_date
+        diff
+      end
+
+    end
+
+  end
+
+end

--- a/spec/examples/yearly_rule_spec.rb
+++ b/spec/examples/yearly_rule_spec.rb
@@ -48,5 +48,12 @@ describe IceCube::YearlyRule, 'occurs_on?' do
     #check assumption
     schedule.occurrences(Time.utc(2010, 12, 31)).size.should == 2
   end
+  
+  it 'should correctly schedule based on Pascha offsets' do
+    schedule = IceCube::Schedule.new(Time.utc(2013, 1, 1))
+    schedule.add_recurrence_rule IceCube::Rule.yearly.offset_from_pascha(-8)
+    #check assumption
+    schedule.occurrences(Time.utc(2013, 4, 27)).size.should == 1
+  end
 
 end


### PR DESCRIPTION
I don't really expect this to be accepted, since I assume it doesn't have really mainstream appeal, but for an app I'm doing I needed to calculate dates of Orthodox holidays, out which a significant proportion are defined in terms of an offset from the day of Pascha (Orthodox Easter; the date of which changes every year and has a rather crazy definition including first full moons after equinoxes and such stuff).

So this pull adds a validation `offset_from_pascha` which accepts a numerical offset from the day of Pascha that year.

It could be pretty easily extended for other religions simply by having a parameter that changes the algorithm used for calculating the base day.
