### PR TITLE
EXDATE should be a comma separated list

### DIFF
--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -277,7 +277,9 @@ module IceCube
       pieces.concat recurrence_rules.map { |r| "RRULE:#{r.to_ical}" }
       pieces.concat exception_rules.map { |r| "EXRULE:#{r.to_ical}" }
       pieces.concat recurrence_times.map { |t| "RDATE#{IcalBuilder.ical_format(t, force_utc)}" }
-      pieces.concat exception_times.map { |t| "EXDATE#{IcalBuilder.ical_format(t, force_utc)}" }
+      if exception_times.size > 0
+        pieces << "EXDATE:#{exception_times.map { |t| IcalBuilder.ical_utc_format(t) }.join(",")}"
+      end
       pieces << "DTEND#{IcalBuilder.ical_format(end_time, force_utc)}" if end_time
       pieces.join("\n")
     end

--- a/spec/examples/to_ical_spec.rb
+++ b/spec/examples/to_ical_spec.rb
@@ -156,12 +156,22 @@ describe IceCube, 'to_ical' do
     schedule.to_ical.should == expectation
   end
 
-  it 'should be able to serialize a schedule with an exdate' do
+  it 'should be able to serialize a schedule with one exdate' do
     schedule = IceCube::Schedule.new(Time.utc(2010, 5, 10, 10, 0, 0))
     schedule.add_exception_date Time.utc(2010, 6, 20, 5, 0, 0)
     # test equality
     expectation = "DTSTART:20100510T100000Z\n"
     expectation << "EXDATE:20100620T050000Z"
+    schedule.to_ical.should == expectation
+  end
+
+  it 'should be able to serialize a schedule with multiple exdates' do
+    schedule = IceCube::Schedule.new(Time.utc(2012, 11, 19, 12, 0, 0))
+    schedule.add_exception_date Time.utc(2013, 3, 20, 12, 0, 0)
+    schedule.add_exception_date Time.utc(2013, 7, 1, 12, 0, 0)
+    # test equality
+    expectation = "DTSTART:20121119T120000Z\n"
+    expectation << "EXDATE:20130320T120000Z,20130701T120000Z"
     schedule.to_ical.should == expectation
   end
 


### PR DESCRIPTION
`schedule.to_ical` does not output correctly when there are multiple exception times. Rather than separate `EXDATE:` listings, there should be one followed by a comma separated list of times.
