### PR TITLE
Add start_time information to Schedule.to_s() method

### DIFF
--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -267,7 +267,10 @@ module IceCube
       pieces.concat exrules.map { |t| "not #{t.to_s}" }
       pieces.concat ed.sort.map { |t| "not on #{t.strftime(IceCube.to_s_time_format)}" }
       output = pieces.join(' / ')
-      rrules.count > 0 ? "#{output}, starting on #{start_time.strftime(IceCube.to_s_time_format)}" : output
+      if rrules.count > 0
+        output = "#{output} starting on #{start_time.strftime(IceCube.to_s_time_format)}"
+      end
+      output
     end
 
     # Serialize this schedule to_ical

--- a/spec/examples/to_s_spec.rb
+++ b/spec/examples/to_s_spec.rb
@@ -103,7 +103,7 @@ describe IceCube::Schedule, 'to_s' do
     schedule = IceCube::Schedule.new Time.local(2010, 3, 20)
     schedule.add_recurrence_date Time.local(2010, 3, 20)
     schedule.add_recurrence_rule IceCube::Rule.weekly
-    schedule.to_s.should == 'March 20, 2010 / Weekly'
+    schedule.to_s.should == "March 20, 2010 / Weekly starting on #{Time.local(2010, 3, 20).strftime(IceCube.to_s_time_format)}"
   end
 
   it 'should work with rules and dates and exdates' do
@@ -112,13 +112,13 @@ describe IceCube::Schedule, 'to_s' do
     schedule.add_recurrence_date Time.local(2010, 3, 20)
     schedule.add_exception_date Time.local(2010, 3, 20) # ignored
     schedule.add_exception_date Time.local(2010, 3, 21)
-    schedule.to_s.should == 'Weekly / not on March 20, 2010 / not on March 21, 2010'
+    schedule.to_s.should == "Weekly / not on March 20, 2010 / not on March 21, 2010 starting on #{Time.local(2010, 3, 20).strftime(IceCube.to_s_time_format)}"
   end
 
   it 'should work with a single rrule' do
     schedule = IceCube::Schedule.new Time.local(2010, 3, 20)
     schedule.add_recurrence_rule IceCube::Rule.weekly.day_of_week(:monday => [1])
-    schedule.to_s.should == schedule.rrules[0].to_s
+    schedule.to_s.should == "#{schedule.rrules[0].to_s} starting on #{Time.local(2010, 3, 20).strftime(IceCube.to_s_time_format)}"
   end
 
   it 'should be able to say the last monday of the month' do
@@ -162,21 +162,24 @@ describe IceCube::Schedule, 'to_s' do
   end
 
   it 'should be able to reflect until dates' do
-    schedule = IceCube::Schedule.new(Time.now)
+    t = Time.now
+    schedule = IceCube::Schedule.new(t)
     schedule.rrule IceCube::Rule.weekly.until(Time.local(2012, 2, 3))
-    schedule.to_s.should == 'Weekly until February  3, 2012'
+    schedule.to_s.should == "Weekly until February  3, 2012 starting on #{t.strftime(IceCube.to_s_time_format)}"
   end
 
   it 'should be able to reflect count' do
-    schedule = IceCube::Schedule.new(Time.now)
+    t = Time.now
+    schedule = IceCube::Schedule.new(t)
     schedule.add_recurrence_rule IceCube::Rule.weekly.count(1)
-    schedule.to_s.should == 'Weekly 1 time'
+    schedule.to_s.should == "Weekly 1 time starting on #{t.strftime(IceCube.to_s_time_format)}"
   end
 
   it 'should be able to reflect count (proper pluralization)' do
-    schedule = IceCube::Schedule.new(Time.now)
+    t = Time.now
+    schedule = IceCube::Schedule.new(t)
     schedule.add_recurrence_rule IceCube::Rule.weekly.count(2)
-    schedule.to_s.should == 'Weekly 2 times'
+    schedule.to_s.should == "Weekly 2 times starting on #{t.strftime(IceCube.to_s_time_format)}"
   end
 
 end


### PR DESCRIPTION
Hi,

This is a small patch to add start date information to the `IceCube::Schedule.to_s()` method. Essentially, it adds information on the timeframe when a recurring schedule is relevant. For example, rather than stating that a schedule is "Weekly," `to_s()` would output "Weekly, starting on December 12th 2012."

Please let me know if you have any comments on this (especially on the style, etc.) or if this isn't the type of change that you're looking for. Also, thanks for maintaining this library, it's really helpful!

Best,
Kevin
