### PR TITLE
fix double WEEKLY string in to_ical result

### DIFF
--- a/lib/ice_cube/rule.rb
+++ b/lib/ice_cube/rule.rb
@@ -47,8 +47,11 @@ module IceCube
     def self.from_hash(original_hash)
       hash = IceCube::FlexibleHash.new original_hash
       return nil unless match = hash[:rule_type].match(/\:\:(.+?)Rule/)
-      rule = IceCube::Rule.send(match[1].downcase.to_sym, hash[:interval] || 1)
-      rule.interval(hash[:interval] || 1, TimeUtil.wday_to_sym(hash[:week_start] || 0)) if match[1] == "Weekly"
+      if match[1] == "Weekly"
+        rule = IceCube::Rule.send(match[1].downcase.to_sym, hash[:interval] || 1, TimeUtil.wday_to_sym(hash[:week_start] || 0))
+      else
+        rule = IceCube::Rule.send(match[1].downcase.to_sym, hash[:interval] || 1)
+      end
       rule.until(TimeUtil.deserialize_time(hash[:until])) if hash[:until]
       rule.count(hash[:count]) if hash[:count]
       hash[:validations] && hash[:validations].each do |key, value|

--- a/spec/examples/to_ical_spec.rb
+++ b/spec/examples/to_ical_spec.rb
@@ -243,4 +243,14 @@ describe IceCube, 'to_ical' do
     rule.to_ical.should == "FREQ=WEEKLY;INTERVAL=#{interval};WKST=MO"
   end
 
+  [:yearly, :monthly, :weekly, :daily, :hourly, :minutely, :secondly].each do |type|
+    it "should make a #{type} rule roundtrip with to_yaml and same to_ical results" do
+      rule = IceCube::Rule.send(type)
+
+      yaml_string = rule.to_yaml
+      rule2 = IceCube::Rule.from_yaml(yaml_string)
+      rule.to_ical.should == rule2.to_ical
+    end
+  end
+
 end


### PR DESCRIPTION
Hello :)

I was trying to generate iCal format from schedule which I earlier loaded from yaml. I stumbled across `FREQ=WEEKLY,WEEKLY` results from to_ical. They are incompatible with google calendar to which I tried to import my calendar, and probably with RFC (I didn't check that).
After a bit of digging I found that WeeklyRule has doubled `interval` values which happens while loading yaml. I wrote a test and fixed it, let me know if it needs refactoring :)
