### PR TITLE
Add example for using arrays as parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ schedule.add_recurrence_rule Rule.daily
 schedule.occurring_at?(now + 1800) # true
 schedule.occurring_between?(t1, t2)
 
+# or set a recurrence rule for every monday and friday every two weeks.
+schedule = Schedule.new
+schedule.add_recurrence_rule Rule.weekly(2).day(:monday, friday)
+
+# Same as above, but with an splatted array.
+schedule = Schedule.new
+days = [:monday, :friday]
+schedule.add_recurrence_rule Rule.weekly(2).day(*days)
+
 # using end_time also sets the duration 
 schedule = Schedule.new(start = Time.now, :end_time => start + 3600)
 schedule.add_recurrence_rule Rule.daily


### PR DESCRIPTION
I had a problem with the dynamic creation of recurrence rules for more that one day a week. 

If you build an array with all days in which an event should occur, you cannot use the array directly as parameter to some methods, eg. Rule.weekly(2).day([:monday, :friday]). Instead, you have to splat the array - Rule.weekly(2).day(*[:monday, :friday]).

In my opinion, it would be better if the methods would accept arrays too. But at least the readme should contain an example for that (probably frequent) case. So, I have added some lines to the README.md.
