### PR TITLE
Tried to make Rule.monthly tests less time dependent

### DIFF
--- a/spec/examples/ice_cube_spec.rb
+++ b/spec/examples/ice_cube_spec.rb
@@ -179,7 +179,6 @@ describe IceCube::Schedule do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.monthly
     dates = schedule.first(10)
-    puts dates.inspect
     dates.each do |date|
       date.day.should == 31 if ['1', '3', '5', '7', '8', '10', '12'].include? date.month
       date.day.should == 30 if ['4', '6', '9', '11'].include? date.month


### PR DESCRIPTION
Tests suite (specially Rule.monthly) were breaking on running tests on 30th and 31th, so I made tests less time-dependent.

Ok, rspec tests are not beautiful (would consider ugly), if someone could suggest refactor ;)

PR related to https://github.com/seejohnrun/ice_cube/issues/192
