### PR TITLE
TimeUtil.now should use Time.zone.now by default

### DIFF
--- a/lib/ice_cube/time_util.rb
+++ b/lib/ice_cube/time_util.rb
@@ -17,7 +17,7 @@ module IceCube
     }
 
     # Provides a Time.now without the usec, in the reference zone or utc offset
-    def self.now(reference=Time.now)
+    def self.now(reference=Time.zone.now)
       match_zone(Time.at(Time.now.to_i), reference)
     end
 

--- a/spec/examples/schedule_spec.rb
+++ b/spec/examples/schedule_spec.rb
@@ -26,6 +26,17 @@ describe IceCube::Schedule do
     schedule.start_time.should == Time.local(dt.year, dt.month, dt.day, dt.hour, dt.min, dt.sec)
   end
 
+  describe :initialize do
+    before { @old_tz = Time.zone }
+    after  { Time.zone = @old_tz }
+
+    it 'respects the user time zone' do
+      Time.zone = 'Pacific Time (US & Canada)'
+      schedule = IceCube::Schedule.new
+      schedule.start_time.formatted_offset.should == '-08:00'
+    end
+  end
+
   describe :duration do
 
     it 'should be based on end_time' do


### PR DESCRIPTION
This method gets invoked by `IceCube::Schedule`'s initialize method to
set the `@start_time` instance variable, and when this happens it's not
taking the user's time zone into account.