### PR TITLE
Use Enumerator to model occurrences in Schedule

### DIFF
--- a/spec/examples/schedule_spec.rb
+++ b/spec/examples/schedule_spec.rb
@@ -283,6 +283,22 @@ describe IceCube::Schedule do
 
   end
 
+  describe :all_occurrences_enumerator do
+    it 'should be equivalent to all_occurrences in terms of arrays' do
+      schedule = IceCube::Schedule.new(Time.now, :duration => IceCube::ONE_HOUR)
+      schedule.add_recurrence_rule IceCube::Rule.daily.until(Time.now + 3 * IceCube::ONE_DAY)
+      schedule.all_occurrences == schedule.all_occurrences_enumerator.to_a 
+    end
+  end
+
+  describe :remaining_occurrences_enumerator do
+    it 'should be equivalent to remaining_occurrences in terms of arrays' do
+      schedule = IceCube::Schedule.new(Time.now, :duration => IceCube::ONE_HOUR)
+      schedule.add_recurrence_rule IceCube::Rule.daily.until(Time.now + 3 * IceCube::ONE_DAY)
+      schedule.remaining_occurrences == schedule.remaining_occurrences_enumerator.to_a 
+    end
+  end
+
   describe :all_occurrences do
 
     it 'has end times for each occurrence' do


### PR DESCRIPTION
I've been encountering some use-cases where I need to deal with infinite lists of recurring events in a manageable way.  Using an Enumerator to do this in a less-eager fashion seems like a good way to approach the problem.  I replaced find_occurrences() in Schedule with enumerate_occurrences() and rewrote all the calls to find_occurrences() accordingly.  Additionally, I added two methods that emit the underlying enumerator so one can use an enumerator to manage a (potentially infinite) list of occurrences.
