### PR TITLE
Made closing_time argument optional in occurrences

### DIFF
--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -144,7 +144,7 @@ module IceCube
 
     # Get all of the occurrences from the start_time up until a
     # given Time
-    def occurrences(closing_time)
+    def occurrences(closing_time = nil)
       find_occurrences(start_time, closing_time)
     end
 


### PR DESCRIPTION
End time is optional for `occurrences` method. For instance if for a terminating schedule I call `schedule.occurrences`, it throws `wrong number of arguments (0 for 1)` which is ambiguous. It works if I pass `nil`. Since anyway, there is no check to prevent infinite looping incase of non-terminating schedules, I propose that this argument should be made optional.
