### PR TITLE
Wrong timezone in Schedule#occurrences_between

### DIFF
--- a/spec/examples/active_support_spec.rb
+++ b/spec/examples/active_support_spec.rb
@@ -117,6 +117,30 @@ module IceCube
         occurrences_between.should == [Time.utc(2013, 1, 1), Time.utc(2013, 1, 2)]
         occurrences_between.all? { |t| t.time_zone.should == schedule.start_time.time_zone }
       end
+      
+      it "uses schedule zone for occurrences_between with a rule terminated by #count" do
+        utc = Time.utc(2013, 1, 1).in_time_zone('UTC')
+        s = Schedule.new(utc) { |s| s.add_recurrence_rule Rule.daily.count(3) }
+        occurrences_between = s.occurrences_between(reference_time, reference_time + 1.day)
+        occurrences_between.should == [Time.utc(2013, 1, 1), Time.utc(2013, 1, 2)]
+        occurrences_between.all? { |t| t.time_zone.should == schedule.start_time.time_zone }
+      end
+      
+      it "uses schedule zone for occurrences_between with a rule terminated by #until" do
+        utc = Time.utc(2013, 1, 1).in_time_zone('UTC')
+        s = Schedule.new(utc) { |s| s.add_recurrence_rule Rule.daily.until(utc.advance(:days => 3)) }
+        occurrences_between = s.occurrences_between(reference_time, reference_time + 1.day)
+        occurrences_between.should == [Time.utc(2013, 1, 1), Time.utc(2013, 1, 2)]
+        occurrences_between.all? { |t| t.time_zone.should == schedule.start_time.time_zone }
+      end
+      
+      it "uses schedule zone for occurrences_between with an unterminated rule" do
+        utc = Time.utc(2013, 1, 1).in_time_zone('UTC')
+        s = Schedule.new(utc) { |s| s.add_recurrence_rule Rule.daily }
+        occurrences_between = s.occurrences_between(reference_time, reference_time + 1.day)
+        occurrences_between.should == [Time.utc(2013, 1, 1), Time.utc(2013, 1, 2)]
+        occurrences_between.all? { |t| t.time_zone.should == schedule.start_time.time_zone }
+      end
 
     end
   end


### PR DESCRIPTION
Hi,

Schedule#occurrences_between uses the timezone of the dates given as arguments instead of the timezone of the schedule in some cases. I added two failing specs in this pull request that show the problem.

The strange thing is that it seems to depend on the termination condition of the rule: a daily rule with #count works as expected while #until and unterminated daily rules return wrong timezones.
