### PR TITLE
Fix: Occurrence#overnight? did not work for start times on the last day of a month

### DIFF
--- a/lib/ice_cube/occurrence.rb
+++ b/lib/ice_cube/occurrence.rb
@@ -93,7 +93,8 @@ module IceCube
     end
 
     def overnight?
-      midnight = Time.new(start_time.year, start_time.month, start_time.day + 1)
+      offset = start_time + 3600 * 24
+      midnight = Time.new(offset.year, offset.month, offset.day)
       midnight < end_time
     end
   end

--- a/spec/examples/occurrence_spec.rb
+++ b/spec/examples/occurrence_spec.rb
@@ -112,6 +112,11 @@ describe Occurrence do
       occurrence.overnight?.should be_false
     end
 
+    it 'is false for a zero-length occurrence on the last day of a month' do
+      occurrence = Occurrence.new(Time.local(2013, 3, 31))
+      occurrence.overnight?.should be_false
+    end
+
     it 'is false for a duration within a single day' do
       t0 = Time.local(2013, 2, 24, 8, 0, 0)
       occurrence = Occurrence.new(t0, t0 + 3600)
@@ -124,6 +129,12 @@ describe Occurrence do
       occurrence.overnight?.should be_false
     end
 
+    it 'is false for a duration that starts at midnight on the last day of a month' do
+      t0 = Time.local(2013, 3, 31, 0, 0, 0)
+      occurrence = Occurrence.new(t0, t0 + 3600)
+      occurrence.overnight?.should be_false
+    end
+
     it 'is false for a duration that ends at midnight' do
       t0 = Time.local(2013, 2, 24, 23, 0, 0)
       occurrence = Occurrence.new(t0, t0 + 3600)
@@ -132,6 +143,12 @@ describe Occurrence do
 
     it 'is true for a duration that crosses midnight' do
       t0 = Time.local(2013, 2, 24, 23, 0, 0)
+      occurrence = Occurrence.new(t0, t0 + 3601)
+      occurrence.overnight?.should be_true
+    end
+
+    it 'is true for a duration that crosses midnight on the last day of a month' do
+      t0 = Time.local(2013, 3, 31, 23, 0, 0)
       occurrence = Occurrence.new(t0, t0 + 3601)
       occurrence.overnight?.should be_true
     end


### PR DESCRIPTION
When the `overnight?` method was called on an occurrence with a start time on the last day of a month, it threw an `argument out of range` exception.

```
[1] pry(main)> occurrence = IceCube::Occurrence.new Time.new(2014, 3, 31)
=> 2014-03-31 00:00:00 +0200
[2] pry(main)> occurrence.overnight?
ArgumentError: argument out of range
from /Users/phil/.rvm/gems/ruby-2.0.0-p353@iq/gems/ice_cube-0.11.3/lib/ice_cube/occurrence.rb:96:in `initialize'
```
