### PR TITLE
Add deprecations and settings for compatibility

### DIFF
--- a/lib/ice_cube.rb
+++ b/lib/ice_cube.rb
@@ -74,4 +74,14 @@ module IceCube
   def self.to_s_time_format=(format)
     @to_s_time_format = format
   end
+
+  # Retain backwards compatibility for schedules exported from older versions
+  # This represents the version number, 11 = 0.11, 1.0 will be 100
+  def self.compatibility
+    @compatibility ||= 11
+  end
+
+  def self.compatibility=(version)
+    @compatibility = version
+  end
 end

--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -350,10 +350,13 @@ module IceCube
     # Convert the schedule to a hash
     def to_hash
       data = {}
-      data[:start_date] = TimeUtil.serialize_time(start_time)
+      data[:start_time] = TimeUtil.serialize_time(start_time)
+      data[:start_date] = data[:start_time] if IceCube.compatibility <= 11
       data[:end_time] = TimeUtil.serialize_time(end_time) if end_time
       data[:rrules] = recurrence_rules.map(&:to_hash)
-      data[:exrules] = exception_rules.map(&:to_hash)
+      if IceCube.compatibility <= 11 && exception_rules.any?
+        data[:exrules] = exception_rules.map(&:to_hash)
+      end
       data[:rtimes] = recurrence_times.map do |rt|
         TimeUtil.serialize_time(rt)
       end


### PR DESCRIPTION
Changing :start_date to :start_time everywhere will take a while for some users due to serialized schedules that still have this key.

For now we'll export both start_time and start_date in serialized output but this duplication should be removed in the next version.

We will continue to read both :start_date and :start_time, with a preference for the new :start_time.
