### PR TITLE
Fix gemspec and run transpec

### DIFF
--- a/ice_cube.gemspec
+++ b/ice_cube.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "ice-cube"
 
   s.add_development_dependency('rake')
-  s.add_development_dependency('rspec', '~> 2.12.0')
+  s.add_development_dependency('rspec', '>= 2.12.0')
   s.add_development_dependency('activesupport', '>= 3.0.0')
   s.add_development_dependency('tzinfo')
 end

--- a/ice_cube.gemspec
+++ b/ice_cube.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "ice-cube"
 
   s.add_development_dependency('rake')
-  s.add_development_dependency('rspec', '>= 2.12.0')
+  s.add_development_dependency('rspec', '~> 2.14.0')
   s.add_development_dependency('activesupport', '>= 3.0.0')
   s.add_development_dependency('tzinfo')
 end

--- a/spec/examples/_no_active_support_spec.rb
+++ b/spec/examples/_no_active_support_spec.rb
@@ -7,7 +7,7 @@ module IceCube
   describe TimeUtil, :if_active_support_time => false do
 
     before do
-      Time.any_instance.should_receive(:respond_to?).with(:time_zone).
+      expect_any_instance_of(Time).to receive(:respond_to?).with(:time_zone).
         at_least(1).times.and_return(false)
     end
 
@@ -17,14 +17,14 @@ module IceCube
         it 'should be able to calculate end of dates without active_support' do
           date        = Date.new(2011, 1, 1)
           end_of_date = Time.local(2011, 1, 1, 23, 59, 59)
-          TimeUtil.end_of_date(date).to_s.should == end_of_date.to_s
+          expect(TimeUtil.end_of_date(date).to_s).to eq(end_of_date.to_s)
         end
 
         it 'should be able to calculate beginning of dates without active_support' do
           date = Date.new(2011, 1, 1)
           res = [ TimeUtil.beginning_of_date(date), Time.local(2011, 1, 1, 0, 0, 0) ]
           res.all? { |r| r.class.name == 'Time' }
-          res.map(&:to_s).uniq.size.should == 1
+          expect(res.map(&:to_s).uniq.size).to eq(1)
         end
 
         it 'should serialize to hash without error' do

--- a/spec/examples/active_support_spec.rb
+++ b/spec/examples/active_support_spec.rb
@@ -17,64 +17,64 @@ module IceCube
     it 'works with a single recurrence time starting from a TimeWithZone' do
       schedule = Schedule.new(t0 = Time.zone.parse("2010-02-05 05:00:00"))
       schedule.add_recurrence_time t0
-      schedule.all_occurrences.should == [t0]
+      expect(schedule.all_occurrences).to eq([t0])
     end
 
     it 'works with a monthly recurrence rule starting from a TimeWithZone' do
       schedule = Schedule.new(t0 = Time.zone.parse("2010-02-05 05:00:00"))
       schedule.add_recurrence_rule Rule.monthly
-      schedule.first(10).should == [
+      expect(schedule.first(10)).to eq([
         Time.zone.parse("2010-02-05 05:00"), Time.zone.parse("2010-03-05 05:00"),
         Time.zone.parse("2010-04-05 05:00"), Time.zone.parse("2010-05-05 05:00"),
         Time.zone.parse("2010-06-05 05:00"), Time.zone.parse("2010-07-05 05:00"),
         Time.zone.parse("2010-08-05 05:00"), Time.zone.parse("2010-09-05 05:00"),
         Time.zone.parse("2010-10-05 05:00"), Time.zone.parse("2010-11-05 05:00")
-      ]
+      ])
     end
 
     it 'works with a monthly schedule converting to UTC across DST' do
       Time.zone = 'Eastern Time (US & Canada)'
       schedule = Schedule.new(t0 = Time.zone.parse("2009-10-28 19:30:00"))
       schedule.add_recurrence_rule Rule.monthly
-      schedule.first(7).map { |d| d.getutc }.should == [
+      expect(schedule.first(7).map { |d| d.getutc }).to eq([
         Time.utc(2009, 10, 28, 23, 30, 0), Time.utc(2009, 11, 29,  0, 30, 0),
         Time.utc(2009, 12, 29,  0, 30, 0), Time.utc(2010,  1, 29,  0, 30, 0),
         Time.utc(2010,  3,  1,  0, 30, 0), Time.utc(2010,  3, 28, 23, 30, 0),
         Time.utc(2010,  4, 28, 23, 30, 0)
-      ]
+      ])
     end
 
     it 'can round trip TimeWithZone to YAML' do
       schedule = Schedule.new(t0 = Time.zone.parse("2010-02-05 05:00:00"))
       schedule.add_recurrence_time t0
       schedule2 = Schedule.from_yaml(schedule.to_yaml)
-      schedule.all_occurrences.should == schedule2.all_occurrences
+      expect(schedule.all_occurrences).to eq(schedule2.all_occurrences)
     end
 
     it 'uses local zone from start time to determine occurs_on? from the beginning of day' do
       schedule = Schedule.new(t0 = Time.local(2009, 2, 7, 23, 59, 59))
       schedule.add_recurrence_rule Rule.daily
-      schedule.occurs_on?(Date.new(2009, 2, 7)).should be_true
+      expect(schedule.occurs_on?(Date.new(2009, 2, 7))).to be_true
     end
 
     it 'uses local zone from start time to determine occurs_on? to the end of day' do
       schedule = Schedule.new(t0 = Time.local(2009, 2, 7, 0, 0, 0))
       schedule.add_recurrence_rule Rule.daily
-      schedule.occurs_on?(Date.new(2009, 2, 7)).should be_true
+      expect(schedule.occurs_on?(Date.new(2009, 2, 7))).to be_true
     end
 
     it 'should use the correct zone for next_occurrences before start_time' do
       future_time = Time.zone.now.beginning_of_day + 1.day
       schedule = Schedule.new(future_time)
       schedule.add_recurrence_rule Rule.daily
-      schedule.next_occurrence.time_zone.should == schedule.start_time.time_zone
+      expect(schedule.next_occurrence.time_zone).to eq(schedule.start_time.time_zone)
     end
 
     it 'should use the correct zone for next_occurrences after start_time' do
       past_time = Time.zone.now.beginning_of_day
       schedule = Schedule.new(past_time)
       schedule.add_recurrence_rule Rule.daily
-      schedule.next_occurrence.time_zone.should == schedule.start_time.time_zone
+      expect(schedule.next_occurrence.time_zone).to eq(schedule.start_time.time_zone)
     end
 
     describe 'querying with time arguments for a different zone' do
@@ -90,39 +90,39 @@ module IceCube
 
       it 'uses schedule zone for next_occurrence' do
         next_occurrence = schedule.next_occurrence(reference_time)
-        next_occurrence.should == Time.utc(2013, 1, 2)
-        next_occurrence.time_zone.should == schedule.start_time.time_zone
+        expect(next_occurrence).to eq(Time.utc(2013, 1, 2))
+        expect(next_occurrence.time_zone).to eq(schedule.start_time.time_zone)
       end
 
       it 'uses schedule zone for next_occurrences' do
         next_occurrences = schedule.next_occurrences(2, reference_time)
-        next_occurrences.should == [Time.utc(2013, 1, 2), Time.utc(2013, 1, 3)]
+        expect(next_occurrences).to eq([Time.utc(2013, 1, 2), Time.utc(2013, 1, 3)])
         next_occurrences.each do |t|
-          t.time_zone.should == schedule.start_time.time_zone
+          expect(t.time_zone).to eq(schedule.start_time.time_zone)
         end
       end
 
       it 'uses schedule zone for remaining_occurrences' do
         remaining_occurrences = schedule.remaining_occurrences(reference_time + 1.day)
-        remaining_occurrences.should == [Time.utc(2013, 1, 2), Time.utc(2013, 1, 3)]
+        expect(remaining_occurrences).to eq([Time.utc(2013, 1, 2), Time.utc(2013, 1, 3)])
         remaining_occurrences.each do |t|
-          t.time_zone.should == schedule.start_time.time_zone
+          expect(t.time_zone).to eq(schedule.start_time.time_zone)
         end
       end
 
       it 'uses schedule zone for occurrences' do
         occurrences = schedule.occurrences(reference_time + 1.day)
-        occurrences.should == [Time.utc(2013, 1, 1), Time.utc(2013, 1, 2)]
+        expect(occurrences).to eq([Time.utc(2013, 1, 1), Time.utc(2013, 1, 2)])
         occurrences.each do |t|
-          t.time_zone.should == schedule.start_time.time_zone
+          expect(t.time_zone).to eq(schedule.start_time.time_zone)
         end
       end
 
       it 'uses schedule zone for occurrences_between' do
         occurrences_between = schedule.occurrences_between(reference_time, reference_time + 1.day)
-        occurrences_between.should == [Time.utc(2013, 1, 1), Time.utc(2013, 1, 2)]
+        expect(occurrences_between).to eq([Time.utc(2013, 1, 1), Time.utc(2013, 1, 2)])
         occurrences_between.each do |t|
-          t.time_zone.should == schedule.start_time.time_zone
+          expect(t.time_zone).to eq(schedule.start_time.time_zone)
         end
       end
 
@@ -130,9 +130,9 @@ module IceCube
         utc = Time.utc(2013, 1, 1).in_time_zone('UTC')
         s = Schedule.new(utc) { |s| s.add_recurrence_rule Rule.daily.count(3) }
         occurrences_between = s.occurrences_between(reference_time, reference_time + 1.day)
-        occurrences_between.should == [Time.utc(2013, 1, 1), Time.utc(2013, 1, 2)]
+        expect(occurrences_between).to eq([Time.utc(2013, 1, 1), Time.utc(2013, 1, 2)])
         occurrences_between.each do |t|
-          t.time_zone.should == schedule.start_time.time_zone
+          expect(t.time_zone).to eq(schedule.start_time.time_zone)
         end
       end
 
@@ -140,9 +140,9 @@ module IceCube
         utc = Time.utc(2013, 1, 1).in_time_zone('UTC')
         s = Schedule.new(utc) { |s| s.add_recurrence_rule Rule.daily.until(utc.advance(:days => 3)) }
         occurrences_between = s.occurrences_between(reference_time, reference_time + 1.day)
-        occurrences_between.should == [Time.utc(2013, 1, 1), Time.utc(2013, 1, 2)]
+        expect(occurrences_between).to eq([Time.utc(2013, 1, 1), Time.utc(2013, 1, 2)])
         occurrences_between.each do |t|
-          t.time_zone.should == schedule.start_time.time_zone
+          expect(t.time_zone).to eq(schedule.start_time.time_zone)
         end
       end
 
@@ -150,9 +150,9 @@ module IceCube
         utc = Time.utc(2013, 1, 1).in_time_zone('UTC')
         s = Schedule.new(utc) { |s| s.add_recurrence_rule Rule.daily }
         occurrences_between = s.occurrences_between(reference_time, reference_time + 1.day)
-        occurrences_between.should == [Time.utc(2013, 1, 1), Time.utc(2013, 1, 2)]
+        expect(occurrences_between).to eq([Time.utc(2013, 1, 1), Time.utc(2013, 1, 2)])
         occurrences_between.each do |t|
-          t.time_zone.should == schedule.start_time.time_zone
+          expect(t.time_zone).to eq(schedule.start_time.time_zone)
         end
       end
 
@@ -167,7 +167,7 @@ describe IceCube::Occurrence do
     occurrence = Occurrence.new(start_time)
 
     difference = (start_time + 60) - occurrence
-    difference.should == 60
+    expect(difference).to eq(60)
   end
 
 end

--- a/spec/examples/daily_rule_spec.rb
+++ b/spec/examples/daily_rule_spec.rb
@@ -4,12 +4,12 @@ module IceCube
   describe DailyRule, 'interval validation' do
     it 'converts a string integer to an actual int when using the interval method' do
       rule = Rule.daily.interval("2")
-      rule.validations_for(:interval).first.interval.should == 2
+      expect(rule.validations_for(:interval).first.interval).to eq(2)
     end
 
     it 'converts a string integer to an actual int when using the initializer' do
       rule = Rule.daily("3")
-      rule.validations_for(:interval).first.interval.should == 3
+      expect(rule.validations_for(:interval).first.interval).to eq(3)
     end
 
     it 'raises an argument error when a bad value is passed using the interval method' do

--- a/spec/examples/daily_rule_spec.rb
+++ b/spec/examples/daily_rule_spec.rb
@@ -32,31 +32,31 @@ module IceCube
       it 'should include nearest time in DST start hour' do
         schedule = Schedule.new(t0 = Time.local(2013, 3, 9, 2, 30, 0))
         schedule.add_recurrence_rule Rule.daily
-        schedule.first(3).should == [
+        expect(schedule.first(3)).to eq([
           Time.local(2013, 3,  9, 2, 30, 0), # -0800
           Time.local(2013, 3, 10, 3, 30, 0), # -0700
           Time.local(2013, 3, 11, 2, 30, 0)  # -0700
-        ]
+        ])
       end
 
       it 'should not skip times in DST end hour' do
         schedule = Schedule.new(t0 = Time.local(2013, 11, 2, 2, 30, 0))
         schedule.add_recurrence_rule Rule.daily
-        schedule.first(3).should == [
+        expect(schedule.first(3)).to eq([
           Time.local(2013, 11, 2, 2, 30, 0), # -0700
           Time.local(2013, 11, 3, 2, 30, 0), # -0800
           Time.local(2013, 11, 4, 2, 30, 0)  # -0800
-        ]
+        ])
       end
 
       it 'should include nearest time to DST start when locking hour_of_day' do
         schedule = Schedule.new(t0 = Time.local(2013, 3, 9, 2, 0, 0))
         schedule.add_recurrence_rule Rule.daily.hour_of_day(2)
-        schedule.first(3).should == [
+        expect(schedule.first(3)).to eq([
           Time.local(2013, 3,  9, 2, 0, 0), # -0800
           Time.local(2013, 3, 10, 3, 0, 0), # -0700
           Time.local(2013, 3, 11, 2, 0, 0)  # -0700
-        ]
+        ])
       end
 
     end
@@ -65,7 +65,7 @@ module IceCube
       schedule = double(start_time: t0 = Time.now)
       rule = Rule.daily(7)
       rule.interval(5)
-      rule.next_time(t0 + 1, schedule, nil).should == t0 + 5 * ONE_DAY
+      expect(rule.next_time(t0 + 1, schedule, nil)).to eq(t0 + 5 * ONE_DAY)
     end
 
     it 'should produce the correct days for @interval = 1' do
@@ -73,8 +73,8 @@ module IceCube
       schedule.add_recurrence_rule Rule.daily
       #check assumption
       times = schedule.occurrences(t0 + 2 * ONE_DAY)
-      times.size.should == 3
-      times.should == [t0, t0 + ONE_DAY, t0 + 2 * ONE_DAY]
+      expect(times.size).to eq(3)
+      expect(times).to eq([t0, t0 + ONE_DAY, t0 + 2 * ONE_DAY])
     end
 
     it 'should produce the correct days for @interval = 2' do
@@ -82,8 +82,8 @@ module IceCube
       schedule.add_recurrence_rule Rule.daily(2)
       #check assumption (3) -- (1) 2 (3) 4 (5) 6
       times = schedule.occurrences(t0 + 5 * ONE_DAY)
-      times.size.should == 3
-      times.should == [t0, t0 + 2 * ONE_DAY, t0 + 4 * ONE_DAY]
+      expect(times.size).to eq(3)
+      expect(times).to eq([t0, t0 + 2 * ONE_DAY, t0 + 4 * ONE_DAY])
     end
 
     it 'should produce the correct days for @interval = 2 when crossing into a new year' do
@@ -91,8 +91,8 @@ module IceCube
       schedule.add_recurrence_rule Rule.daily(2)
       #check assumption (3) -- (1) 2 (3) 4 (5) 6
       times = schedule.occurrences(t0 + 5 * ONE_DAY)
-      times.size.should == 3
-      times.should == [t0, t0 + 2 * ONE_DAY, t0 + 4 * ONE_DAY]
+      expect(times.size).to eq(3)
+      expect(times).to eq([t0, t0 + 2 * ONE_DAY, t0 + 4 * ONE_DAY])
     end
 
     it 'should produce the correct days for interval of 4 day with hour and minute of day set' do
@@ -100,10 +100,10 @@ module IceCube
       schedule.add_recurrence_rule Rule.daily(4).hour_of_day(5).minute_of_hour(45)
       #check assumption 2 -- 1 (2) (3) (4) 5 (6)
       times = schedule.occurrences(t0 + 5 * ONE_DAY)
-      times.should == [
+      expect(times).to eq([
         t0 + 5 * ONE_HOUR + 45 * ONE_MINUTE,
         t0 + 4 * ONE_DAY + 5 * ONE_HOUR + 45 * ONE_MINUTE
-      ]
+      ])
     end
 
   end

--- a/spec/examples/dst_spec.rb
+++ b/spec/examples/dst_spec.rb
@@ -8,11 +8,11 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.daily.count(20)
     dates = schedule.first(20)
-    dates.size.should == 20
+    expect(dates.size).to eq(20)
     #check assumptions
     dates.each do |date|
-      date.utc?.should_not == true
-      date.hour.should == 5
+      expect(date.utc?).not_to eq(true)
+      expect(date.hour).to eq(5)
     end
   end
 
@@ -22,11 +22,11 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.daily.count(20)
     dates = schedule.first(20)
-    dates.size.should == 20
+    expect(dates.size).to eq(20)
     #check assumptions
     dates.each do |date|
-      date.utc?.should_not == true
-      date.hour.should == 5
+      expect(date.utc?).not_to eq(true)
+      expect(date.hour).to eq(5)
     end
   end
 
@@ -38,7 +38,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     dates = schedule.occurrences(start_date + 20 * IceCube::ONE_DAY)
     last = start_date
     dates.each do |date|
-      date.hour.should == 5
+      expect(date.hour).to eq(5)
       last = date
     end
   end
@@ -51,7 +51,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     #check assumption
     distance_in_hours = 0
     dates.each do |d|
-      d.should == start_date + IceCube::ONE_HOUR * distance_in_hours
+      expect(d).to eq(start_date + IceCube::ONE_HOUR * distance_in_hours)
       distance_in_hours += 2
     end
   end
@@ -64,7 +64,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     #check assumption
     distance_in_minutes = 0
     dates.each do |d|
-      d.should == start_date + IceCube::ONE_MINUTE * distance_in_minutes
+      expect(d).to eq(start_date + IceCube::ONE_MINUTE * distance_in_minutes)
       distance_in_minutes += 30
     end
   end
@@ -77,7 +77,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     #check assumption
     distance_in_seconds = 0
     dates.each do |d|
-      d.should == start_date + distance_in_seconds
+      expect(d).to eq(start_date + distance_in_seconds)
       distance_in_seconds += 120
     end
   end
@@ -89,9 +89,9 @@ describe IceCube::Schedule, 'occurs_on?' do
     dates = schedule.first(10)
     #check assumption
     dates.each do |d|
-      d.hour.should == start_date.hour
-      d.min.should == start_date.min
-      d.sec.should == start_date.sec
+      expect(d.hour).to eq(start_date.hour)
+      expect(d.min).to eq(start_date.min)
+      expect(d.sec).to eq(start_date.sec)
     end
   end
 
@@ -102,10 +102,10 @@ describe IceCube::Schedule, 'occurs_on?' do
     dates = schedule.first(10)
     #check assumption
     dates.each do |d|
-      d.day.should == start_date.day
-      d.hour.should == start_date.hour
-      d.min.should == start_date.min
-      d.sec.should == start_date.sec
+      expect(d.day).to eq(start_date.day)
+      expect(d.hour).to eq(start_date.hour)
+      expect(d.min).to eq(start_date.min)
+      expect(d.sec).to eq(start_date.sec)
     end
   end
 
@@ -116,11 +116,11 @@ describe IceCube::Schedule, 'occurs_on?' do
     dates = schedule.first(10)
     #check assumption
     dates.each do |d|
-      d.month.should == start_date.month
-      d.day.should == start_date.day
-      d.hour.should == start_date.hour
-      d.min.should == start_date.min
-      d.sec.should == start_date.sec
+      expect(d.month).to eq(start_date.month)
+      expect(d.day).to eq(start_date.day)
+      expect(d.hour).to eq(start_date.hour)
+      expect(d.min).to eq(start_date.min)
+      expect(d.sec).to eq(start_date.sec)
     end
   end
 
@@ -130,7 +130,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.daily.until(end_date)
     #make sure we end on the proper time
-    schedule.all_occurrences.last.should == end_date
+    expect(schedule.all_occurrences.last).to eq(end_date)
   end
 
   it 'UTC - has an until date on a rule that is over a DST from the start date' do
@@ -139,7 +139,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.daily.until(end_date)
     #make sure we end on the proper time
-    schedule.all_occurrences.last.should == end_date
+    expect(schedule.all_occurrences.last).to eq(end_date)
   end
 
   it 'LOCAL - has an until date on a rule that is over a DST from the start date (other direction)' do
@@ -148,7 +148,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.daily.until(end_date)
     #make sure we end on the proper time
-    schedule.all_occurrences.last.should == end_date
+    expect(schedule.all_occurrences.last).to eq(end_date)
   end
 
   it 'UTC - has an until date on a rule that is over a DST from the start date (other direction)' do
@@ -157,7 +157,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.daily.until(end_date)
     #make sure we end on the proper time
-    schedule.all_occurrences.last.should == end_date
+    expect(schedule.all_occurrences.last).to eq(end_date)
   end
 
   it 'LOCAL - has an end date on a rule that is over a DST from the start date' do
@@ -166,7 +166,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.daily
     #make sure we end on the proper time
-    schedule.occurrences(end_date).last.should == end_date
+    expect(schedule.occurrences(end_date).last).to eq(end_date)
   end
 
   it 'UTC - has an end date on a rule that is over a DST from the start date' do
@@ -175,7 +175,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.daily
     #make sure we end on the proper time
-    schedule.occurrences(end_date).last.should == end_date
+    expect(schedule.occurrences(end_date).last).to eq(end_date)
   end
 
   it 'LOCAL - has an end date on a rule that is over a DST from the start date (other direction)' do
@@ -184,7 +184,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.daily
     #make sure we end on the proper time
-    schedule.occurrences(end_date).last.should == end_date
+    expect(schedule.occurrences(end_date).last).to eq(end_date)
   end
 
   it 'UTC - has an end date on a rule that is over a DST from the start date (other direction)' do
@@ -193,88 +193,88 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.daily
     #make sure we end on the proper time
-    schedule.occurrences(end_date).last.should == end_date
+    expect(schedule.occurrences(end_date).last).to eq(end_date)
   end
 
   it 'local - should make dates on interval over dst - github issue 4' do
     start_date = Time.local(2010, 3, 12, 19, 0, 0)
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.daily(3)
-    schedule.first(3).should == [Time.local(2010, 3, 12, 19, 0, 0), Time.local(2010, 3, 15, 19, 0, 0), Time.local(2010, 3, 18, 19, 0, 0)]
+    expect(schedule.first(3)).to eq([Time.local(2010, 3, 12, 19, 0, 0), Time.local(2010, 3, 15, 19, 0, 0), Time.local(2010, 3, 18, 19, 0, 0)])
   end
 
   it 'local - should make dates on monthly interval over dst - github issue 4' do
     start_date = Time.local(2010, 3, 12, 19, 0, 0)
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.monthly(2)
-    schedule.first(6).should == [Time.local(2010, 3, 12, 19, 0, 0), Time.local(2010, 5, 12, 19, 0, 0), Time.local(2010, 7, 12, 19, 0, 0),
-                                 Time.local(2010, 9, 12, 19, 0, 0), Time.local(2010, 11, 12, 19, 0, 0), Time.local(2011, 1, 12, 19, 0, 0)]
+    expect(schedule.first(6)).to eq([Time.local(2010, 3, 12, 19, 0, 0), Time.local(2010, 5, 12, 19, 0, 0), Time.local(2010, 7, 12, 19, 0, 0),
+                                 Time.local(2010, 9, 12, 19, 0, 0), Time.local(2010, 11, 12, 19, 0, 0), Time.local(2011, 1, 12, 19, 0, 0)])
   end
 
   it 'local - should make dates on monthly interval over dst - github issue 4' do
     start_date = Time.local(2010, 3, 12, 19, 0, 0)
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.monthly
-    schedule.first(10).should == [Time.local(2010, 3, 12, 19, 0, 0), Time.local(2010, 4, 12, 19, 0, 0), Time.local(2010, 5, 12, 19, 0, 0),
+    expect(schedule.first(10)).to eq([Time.local(2010, 3, 12, 19, 0, 0), Time.local(2010, 4, 12, 19, 0, 0), Time.local(2010, 5, 12, 19, 0, 0),
                                   Time.local(2010, 6, 12, 19, 0, 0), Time.local(2010, 7, 12, 19, 0, 0), Time.local(2010, 8, 12, 19, 0, 0),
                                   Time.local(2010, 9, 12, 19, 0, 0), Time.local(2010, 10, 12, 19, 0, 0), Time.local(2010, 11, 12, 19, 0, 0),
-                                  Time.local(2010, 12, 12, 19, 0, 0)]
+                                  Time.local(2010, 12, 12, 19, 0, 0)])
   end
 
   it 'local - should make dates on yearly interval over dst - github issue 4' do
     start_date = Time.local(2010, 3, 12, 19, 0, 0)
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.yearly(2)
-    schedule.first(3).should == [Time.local(2010, 3, 12, 19, 0, 0), Time.local(2012, 3, 12, 19, 0, 0), Time.local(2014, 3, 12, 19, 0, 0)]
+    expect(schedule.first(3)).to eq([Time.local(2010, 3, 12, 19, 0, 0), Time.local(2012, 3, 12, 19, 0, 0), Time.local(2014, 3, 12, 19, 0, 0)])
   end
 
   it "local - should make dates on monthly (day of week) inverval over dst - github issue 5" do
     start_date = Time.local(2010, 3, 7, 12, 0, 0)
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.monthly.day_of_week(:sunday => [1])
-    schedule.first(3).should == [Time.local(2010, 3, 7, 12, 0, 0), Time.local(2010, 4, 4, 12, 0, 0), Time.local(2010, 5, 2, 12, 0, 0)]
+    expect(schedule.first(3)).to eq([Time.local(2010, 3, 7, 12, 0, 0), Time.local(2010, 4, 4, 12, 0, 0), Time.local(2010, 5, 2, 12, 0, 0)])
   end
 
   it "local - should make dates on monthly (day of month) inverval over dst - github issue 5" do
     start_date = Time.local(2010, 3, 1, 12, 0, 0)
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.monthly.day_of_month(1)
-    schedule.first(3).should == [Time.local(2010, 3, 1, 12, 0, 0), Time.local(2010, 4, 1, 12, 0, 0), Time.local(2010, 5, 1, 12, 0, 0)]
+    expect(schedule.first(3)).to eq([Time.local(2010, 3, 1, 12, 0, 0), Time.local(2010, 4, 1, 12, 0, 0), Time.local(2010, 5, 1, 12, 0, 0)])
   end
 
   it "local - should make dates on weekly (day) inverval over dst - github issue 5" do
     start_date = Time.local(2010, 3, 7, 12, 0, 0)
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.weekly.day(:sunday)
-    schedule.first(3).should == [Time.local(2010, 3, 7, 12, 0, 0), Time.local(2010, 3, 14, 12, 0, 0), Time.local(2010, 3, 21, 12, 0, 0)]
+    expect(schedule.first(3)).to eq([Time.local(2010, 3, 7, 12, 0, 0), Time.local(2010, 3, 14, 12, 0, 0), Time.local(2010, 3, 21, 12, 0, 0)])
   end
 
   it "local - should make dates on monthly (day of year) inverval over dst - github issue 5" do
     start_date = Time.local(2010, 3, 7, 12, 0, 0)
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.monthly.day_of_year(1)
-    schedule.first(3).should == [Time.local(2011, 1, 1, 12, 0, 0), Time.local(2012, 1, 1, 12, 0, 0), Time.local(2013, 1, 1, 12, 0, 0)]
+    expect(schedule.first(3)).to eq([Time.local(2011, 1, 1, 12, 0, 0), Time.local(2012, 1, 1, 12, 0, 0), Time.local(2013, 1, 1, 12, 0, 0)])
   end
 
   it "local - should make dates on monthly (month_of_year) inverval over dst - github issue 5" do
     start_date = Time.local(2010, 3, 7, 12, 0, 0)
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.yearly.month_of_year(:april).day_of_month(10)
-    schedule.first(3).should == [Time.local(2010, 4, 10, 12, 0, 0), Time.local(2011, 4, 10, 12, 0, 0), Time.local(2012, 4, 10, 12, 0, 0)]
+    expect(schedule.first(3)).to eq([Time.local(2010, 4, 10, 12, 0, 0), Time.local(2011, 4, 10, 12, 0, 0), Time.local(2012, 4, 10, 12, 0, 0)])
   end
 
   it "skips double occurrences from end of DST" do
     Time.zone = "America/Denver"
     t0 = Time.zone.parse("Sun, 03 Nov 2013 01:30:00 MDT -06:00")
     schedule = IceCube::Schedule.new(t0) { |s| s.rrule IceCube::Rule.daily.count(3) }
-    schedule.all_occurrences.should == [t0, t0 + 25*ONE_HOUR, t0 + 49*ONE_HOUR]
+    expect(schedule.all_occurrences).to eq([t0, t0 + 25*ONE_HOUR, t0 + 49*ONE_HOUR])
   end
 
   it "does not skip hourly rules over DST" do
     Time.zone = "America/Denver"
     t0 = Time.zone.parse("Sun, 03 Nov 2013 01:30:00 MDT -06:00")
     schedule = IceCube::Schedule.new(t0) { |s| s.rrule IceCube::Rule.hourly.count(3) }
-    schedule.all_occurrences.should == [t0, t0 + ONE_HOUR, t0 + 2*ONE_HOUR]
+    expect(schedule.all_occurrences).to eq([t0, t0 + ONE_HOUR, t0 + 2*ONE_HOUR])
   end
 
   it "does not skip minutely rules with minute of hour over DST" do
@@ -282,7 +282,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     t0 = Time.zone.parse("Sun, 03 Nov 2013 01:30:00 MDT -06:00")
     schedule = IceCube::Schedule.new(t0) { |s| s.rrule IceCube::Rule.hourly.count(3) }
     schedule.rrule IceCube::Rule.minutely.minute_of_hour([0, 15, 30, 45])
-    schedule.first(5).should == [t0, t0 + 15*60, t0 + 30*60, t0 + 45*60, t0 + 60*60]
+    expect(schedule.first(5)).to eq([t0, t0 + 15*60, t0 + 30*60, t0 + 45*60, t0 + 60*60])
   end
 
   it "does not skip minutely rules with second of minute over DST" do
@@ -290,7 +290,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     t0 = Time.zone.parse("Sun, 03 Nov 2013 01:30:00 MDT -06:00")
     schedule = IceCube::Schedule.new(t0) { |s| s.rrule IceCube::Rule.hourly.count(3) }
     schedule.rrule IceCube::Rule.minutely(15).second_of_minute(0)
-    schedule.first(5).should == [t0, t0 + 15*60, t0 + 30*60, t0 + 45*60, t0 + 60*60]
+    expect(schedule.first(5)).to eq([t0, t0 + 15*60, t0 + 30*60, t0 + 45*60, t0 + 60*60])
   end
 
 

--- a/spec/examples/flexible_hash_spec.rb
+++ b/spec/examples/flexible_hash_spec.rb
@@ -7,64 +7,64 @@ module IceCube
 
     describe "#[]" do
       specify ":sym => :sym is found" do
-        hash[:sym].should be true
+        expect(hash[:sym]).to be true
       end
 
       specify "'sym' => :sym is found" do
-        hash["sym"].should be true
+        expect(hash["sym"]).to be true
       end
 
       specify "'str' => 'str' is found" do
-        hash["str"].should be true
+        expect(hash["str"]).to be true
       end
 
       specify ":str => 'str' is found" do
-        hash[:str].should be true
+        expect(hash[:str]).to be true
       end
 
       specify "other types are found" do
-        hash[1].should be true
+        expect(hash[1]).to be true
       end
 
       specify "missing keys are nil" do
-        hash[-1].should be nil
+        expect(hash[-1]).to be nil
       end
     end
 
     describe "#fetch" do
       it "yields missing keys" do
-        hash.fetch(-1) { |k| k == -1 }.should be true
+        expect(hash.fetch(-1) { |k| k == -1 }).to be true
       end
     end
 
     describe "#delete" do
       specify ":sym => :sym is found and removed" do
-        hash.delete(:sym).should be true
-        hash[:sym].should be nil
+        expect(hash.delete(:sym)).to be true
+        expect(hash[:sym]).to be nil
       end
 
       specify "'sym' => :sym is found and removed" do
-        hash.delete("sym").should be true
-        hash["sym"].should be nil
+        expect(hash.delete("sym")).to be true
+        expect(hash["sym"]).to be nil
       end
 
       specify "'str' => 'str' is found and removed" do
-        hash.delete("str").should be true
-        hash["str"].should be nil
+        expect(hash.delete("str")).to be true
+        expect(hash["str"]).to be nil
       end
 
       specify ":str => 'str' is found and removed" do
-        hash.delete(:str).should be true
-        hash[:str].should be nil
+        expect(hash.delete(:str)).to be true
+        expect(hash[:str]).to be nil
       end
 
       specify "other types are found and removed" do
-        hash.delete(1).should be true
-        hash[1].should be nil
+        expect(hash.delete(1)).to be true
+        expect(hash[1]).to be nil
       end
 
       specify "missing keys are nil" do
-        hash.delete(-1).should be nil
+        expect(hash.delete(-1)).to be nil
       end
     end
 

--- a/spec/examples/hash_parser_spec.rb
+++ b/spec/examples/hash_parser_spec.rb
@@ -10,12 +10,23 @@ module IceCube
 
       let(:hash) { {start_time: t, duration: 3600} }
 
-      its(:start_time) { should == t }
-      its(:duration)   { should == 3600 }
+      describe '#start_time' do
+        subject { super().start_time }
+        it { should == t }
+      end
+
+      describe '#duration' do
+        subject { super().duration }
+        it   { should == 3600 }
+      end
 
       describe "end_time overrules duration" do
         let(:hash) { {start_time: t, end_time: t + 1800, duration: 3600} }
-        its(:duration) { should == 1800 }
+
+        describe '#duration' do
+          subject { super().duration }
+          it { should == 1800 }
+        end
       end
     end
 

--- a/spec/examples/hourly_rule_spec.rb
+++ b/spec/examples/hourly_rule_spec.rb
@@ -31,22 +31,22 @@ module IceCube
       it 'should work across DST start hour' do
         schedule = Schedule.new(t0 = Time.local(2013, 3, 10, 1, 0, 0))
         schedule.add_recurrence_rule Rule.hourly
-        schedule.first(3).should == [
+        expect(schedule.first(3)).to eq([
           Time.local(2013, 3, 10, 1, 0, 0), # -0800
           Time.local(2013, 3, 10, 3, 0, 0), # -0700
           Time.local(2013, 3, 10, 4, 0, 0)  # -0700
-        ]
+        ])
       end
 
       it 'should not skip times in DST end hour' do
         schedule = Schedule.new(t0 = Time.local(2013, 11, 3, 0, 0, 0))
         schedule.add_recurrence_rule Rule.hourly
-        schedule.first(4).should == [
+        expect(schedule.first(4)).to eq([
           Time.local(2013, 11, 3, 0, 0, 0),             # -0700
           Time.local(2013, 11, 3, 1, 0, 0) - ONE_HOUR,  # -0700
           Time.local(2013, 11, 3, 1, 0, 0),             # -0800
           Time.local(2013, 11, 3, 2, 0, 0),             # -0800
-        ]
+        ])
       end
 
     end
@@ -55,7 +55,7 @@ module IceCube
       schedule = double(start_time: t0 = Time.now)
       rule = Rule.hourly(7)
       rule.interval(5)
-      rule.next_time(t0 + 1, schedule, nil).should == t0 + 5.hours
+      expect(rule.next_time(t0 + 1, schedule, nil)).to eq(t0 + 5.hours)
     end
 
     it 'should produce the correct days for @interval = 3' do
@@ -65,8 +65,8 @@ module IceCube
       schedule.add_recurrence_rule Rule.hourly(3)
       #check assumption (3) -- (1) 2 (3) 4 (5) 6
       dates = schedule.first(3)
-      dates.size.should == 3
-      dates.should == [DAY, DAY + 3 * ONE_HOUR, DAY + 6 * ONE_HOUR]
+      expect(dates.size).to eq(3)
+      expect(dates).to eq([DAY, DAY + 3 * ONE_HOUR, DAY + 6 * ONE_HOUR])
     end
 
   end

--- a/spec/examples/hourly_rule_spec.rb
+++ b/spec/examples/hourly_rule_spec.rb
@@ -5,12 +5,12 @@ module IceCube
     describe 'interval validation' do
       it 'converts a string integer to an actual int when using the interval method' do
         rule = Rule.hourly.interval("2")
-        rule.validations_for(:interval).first.interval.should == 2
+        expect(rule.validations_for(:interval).first.interval).to eq(2)
       end
 
       it 'converts a string integer to an actual int when using the initializer' do
         rule = Rule.hourly("3")
-        rule.validations_for(:interval).first.interval.should == 3
+        expect(rule.validations_for(:interval).first.interval).to eq(3)
       end
 
       it 'raises an argument error when a bad value is passed' do

--- a/spec/examples/ice_cube_spec.rb
+++ b/spec/examples/ice_cube_spec.rb
@@ -7,7 +7,7 @@ describe IceCube::Schedule do
     rule = IceCube::Rule.daily.day(:monday)
     schedule = IceCube::Schedule.new(Time.now)
     schedule.add_recurrence_rule rule
-    lambda { schedule.first(3) }.should_not raise_error
+    expect { schedule.first(3) }.not_to raise_error
   end
 
   it 'should respond to complex combinations (1)' do
@@ -16,25 +16,25 @@ describe IceCube::Schedule do
     schedule.add_recurrence_rule IceCube::Rule.yearly(2).day(:wednesday).month_of_year(:april)
     #check assumptions
     dates = schedule.occurrences(Time.utc(2011, 12, 31)) #two years
-    dates.size.should == 4
+    expect(dates.size).to eq(4)
     dates.each do |date|
-      date.wday.should == 3
-      date.month.should == 4
-      date.year.should == start_date.year #since we're doing every other
+      expect(date.wday).to eq(3)
+      expect(date.month).to eq(4)
+      expect(date.year).to eq(start_date.year) #since we're doing every other
     end
   end
 
   it 'should return an added occurrence time' do
     schedule = IceCube::Schedule.new(t0 = Time.now)
     schedule.add_recurrence_time(t0 + 2)
-    schedule.occurrences(t0 + 50).should == [t0, t0 + 2]
+    expect(schedule.occurrences(t0 + 50)).to eq([t0, t0 + 2])
   end
 
   it 'should not return an occurrence time that is excluded' do
     schedule = IceCube::Schedule.new(t0 = Time.now)
     schedule.add_recurrence_time(t0 + 2)
     schedule.add_exception_time(t0 + 2)
-    schedule.occurrences(t0 + 50).should == [t0]
+    expect(schedule.occurrences(t0 + 50)).to eq([t0])
   end
 
   it 'should return properly with a combination of a recurrence and exception rule' do
@@ -42,7 +42,7 @@ describe IceCube::Schedule do
     schedule.add_recurrence_rule IceCube::Rule.daily # every day
     schedule.add_exception_rule IceCube::Rule.weekly.day(:monday, :tuesday, :wednesday) # except these
     #check assumption - in 2 weeks, we should have 8 days
-    schedule.occurrences(DAY + 13 * IceCube::ONE_DAY).size.should == 8
+    expect(schedule.occurrences(DAY + 13 * IceCube::ONE_DAY).size).to eq(8)
   end
 
   it 'should be able to exclude a certain date from a range' do
@@ -52,8 +52,8 @@ describe IceCube::Schedule do
     schedule.add_exception_time(start_date + 1 * IceCube::ONE_DAY) # all days except tomorrow
     # check assumption
     dates = schedule.occurrences(start_date + 13 * IceCube::ONE_DAY) # 2 weeks
-    dates.size.should == 13 # 2 weeks minus 1 day
-    dates.should_not include(start_date + 1 * IceCube::ONE_DAY)
+    expect(dates.size).to eq(13) # 2 weeks minus 1 day
+    expect(dates).not_to include(start_date + 1 * IceCube::ONE_DAY)
   end
 
   it 'make a schedule with a start_date not included in a rule, and make sure that count behaves properly' do
@@ -61,9 +61,9 @@ describe IceCube::Schedule do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.weekly.day(:thursday).count(5)
     dates = schedule.all_occurrences
-    dates.uniq.size.should == 5
-    dates.each { |d| d.wday.should == 4 }
-    dates.should_not include(WEDNESDAY)
+    expect(dates.uniq.size).to eq(5)
+    dates.each { |d| expect(d.wday).to eq(4) }
+    expect(dates).not_to include(WEDNESDAY)
   end
 
   it 'make a schedule with a start_date included in a rule, and make sure that count behaves properly' do
@@ -71,9 +71,9 @@ describe IceCube::Schedule do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.weekly.day(:thursday).count(5)
     dates = schedule.all_occurrences
-    dates.uniq.size.should == 5
-    dates.each { |d| d.wday.should == 4 }
-    dates.should include(WEDNESDAY + IceCube::ONE_DAY)
+    expect(dates.uniq.size).to eq(5)
+    dates.each { |d| expect(d.wday).to eq(4) }
+    expect(dates).to include(WEDNESDAY + IceCube::ONE_DAY)
   end
 
   it 'should work as expected with a second_of_minute rule specified' do
@@ -81,14 +81,14 @@ describe IceCube::Schedule do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.weekly.second_of_minute(30)
     dates = schedule.occurrences(start_date + 30 * 60)
-    dates.each { |date| date.sec.should == 30 }
+    dates.each { |date| expect(date.sec).to eq(30) }
   end
 
   it 'ensure that when count on a rule is set to 0, 0 occurrences come back' do
     start_date = DAY
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.daily.count(0)
-    schedule.all_occurrences.should == []
+    expect(schedule.all_occurrences).to eq([])
   end
 
   it 'should be able to be schedules at 1:st:st and 2:st:st every day' do
@@ -96,9 +96,9 @@ describe IceCube::Schedule do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.daily.hour_of_day(1, 2).count(6)
     dates = schedule.all_occurrences
-    dates.should == [Time.utc(2007, 9, 3, 1, 15, 25), Time.utc(2007, 9, 3, 2, 15, 25),
+    expect(dates).to eq([Time.utc(2007, 9, 3, 1, 15, 25), Time.utc(2007, 9, 3, 2, 15, 25),
                      Time.utc(2007, 9, 4, 1, 15, 25), Time.utc(2007, 9, 4, 2, 15, 25),
-                     Time.utc(2007, 9, 5, 1, 15, 25), Time.utc(2007, 9, 5, 2, 15, 25)]
+                     Time.utc(2007, 9, 5, 1, 15, 25), Time.utc(2007, 9, 5, 2, 15, 25)])
   end
 
   it 'should be able to be schedules at 1:0:st and 2:0:st every day' do
@@ -106,9 +106,9 @@ describe IceCube::Schedule do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.daily.hour_of_day(1, 2).minute_of_hour(0).count(6)
     dates = schedule.all_occurrences
-    dates.should == [Time.utc(2007, 9, 3, 1, 0, 25), Time.utc(2007, 9, 3, 2, 0, 25),
+    expect(dates).to eq([Time.utc(2007, 9, 3, 1, 0, 25), Time.utc(2007, 9, 3, 2, 0, 25),
                      Time.utc(2007, 9, 4, 1, 0, 25), Time.utc(2007, 9, 4, 2, 0, 25),
-                     Time.utc(2007, 9, 5, 1, 0, 25), Time.utc(2007, 9, 5, 2, 0, 25)]
+                     Time.utc(2007, 9, 5, 1, 0, 25), Time.utc(2007, 9, 5, 2, 0, 25)])
   end
 
   it 'will only return count# if you specify a count and use .first' do
@@ -116,7 +116,7 @@ describe IceCube::Schedule do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.daily.count(10)
     dates = schedule.first(200)
-    dates.size.should == 10
+    expect(dates.size).to eq(10)
   end
 
   it 'occurs yearly' do
@@ -125,11 +125,11 @@ describe IceCube::Schedule do
     schedule.add_recurrence_rule IceCube::Rule.yearly
     dates = schedule.first(10)
     dates.each do |date|
-      date.month.should == start_date.month
-      date.day.should == start_date.day
-      date.hour.should == start_date.hour
-      date.min.should == start_date.min
-      date.sec.should == start_date.sec
+      expect(date.month).to eq(start_date.month)
+      expect(date.day).to eq(start_date.day)
+      expect(date.hour).to eq(start_date.hour)
+      expect(date.min).to eq(start_date.min)
+      expect(date.sec).to eq(start_date.sec)
     end
   end
 
@@ -139,9 +139,9 @@ describe IceCube::Schedule do
     schedule.add_recurrence_rule IceCube::Rule.daily
     dates = schedule.first(10)
     dates.each do |date|
-      date.hour.should == start_date.hour
-      date.min.should == start_date.min
-      date.sec.should == start_date.sec
+      expect(date.hour).to eq(start_date.hour)
+      expect(date.min).to eq(start_date.min)
+      expect(date.sec).to eq(start_date.sec)
     end
   end
 
@@ -151,8 +151,8 @@ describe IceCube::Schedule do
     schedule.add_recurrence_rule IceCube::Rule.hourly
     dates = schedule.first(10)
     dates.each do |date|
-      date.min.should == start_date.min
-      date.sec.should == start_date.sec
+      expect(date.min).to eq(start_date.min)
+      expect(date.sec).to eq(start_date.sec)
     end
   end
 
@@ -162,7 +162,7 @@ describe IceCube::Schedule do
     schedule.add_recurrence_rule IceCube::Rule.minutely
     dates = schedule.first(10)
     dates.each do |date|
-      date.sec.should == start_date.sec
+      expect(date.sec).to eq(start_date.sec)
     end
   end
 
@@ -175,8 +175,8 @@ describe IceCube::Schedule do
     0.upto(59) { |i| expectation << start_date + i }
     # compare with what we get
     dates = schedule.all_occurrences
-    dates.size.should == 60
-    schedule.all_occurrences.should == expectation
+    expect(dates.size).to eq(60)
+    expect(schedule.all_occurrences).to eq(expectation)
   end
 
   it 'perform a every day LOCAL and make sure we get back LOCAL' do
@@ -185,9 +185,9 @@ describe IceCube::Schedule do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.daily
     schedule.first(10).each do |d|
-      d.utc?.should == false
-      d.hour.should == 5
-      (d.utc_offset == -5 * IceCube::ONE_HOUR || d.utc_offset == -4 * IceCube::ONE_HOUR).should be_true
+      expect(d.utc?).to eq(false)
+      expect(d.hour).to eq(5)
+      expect(d.utc_offset == -5 * IceCube::ONE_HOUR || d.utc_offset == -4 * IceCube::ONE_HOUR).to be_true
     end
   end
 
@@ -196,9 +196,9 @@ describe IceCube::Schedule do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.daily
     schedule.first(10).each do |d|
-      d.utc?.should == true
-      d.utc_offset.should == 0
-      d.hour.should == 5
+      expect(d.utc?).to eq(true)
+      expect(d.utc_offset).to eq(0)
+      expect(d.hour).to eq(5)
     end
   end
 
@@ -211,10 +211,10 @@ describe IceCube::Schedule do
     schedule.add_recurrence_rule IceCube::Rule.daily.until(Time.utc(2010, 11, 10, 8, 0, 0)) #4 o clocal local
     #check assumptions
     dates = schedule.all_occurrences
-    dates.each { |d| d.utc?.should == false }
-    dates.should == [Time.zone.local(2010, 11, 6, 5, 0, 0),
+    dates.each { |d| expect(d.utc?).to eq(false) }
+    expect(dates).to eq([Time.zone.local(2010, 11, 6, 5, 0, 0),
       Time.zone.local(2010, 11, 7, 5, 0, 0), Time.zone.local(2010, 11, 8, 5, 0, 0),
-      Time.zone.local(2010, 11, 9, 5, 0, 0)]
+      Time.zone.local(2010, 11, 9, 5, 0, 0)])
   end
 
   # here we purposely put a local time that is before the range ends, to
@@ -226,10 +226,10 @@ describe IceCube::Schedule do
     schedule.add_recurrence_rule IceCube::Rule.daily.until(Time.zone.local(2010, 11, 9, 23, 0, 0)) #4 o UTC time
     #check assumptions
     dates = schedule.all_occurrences
-    dates.each { |d| d.utc?.should == true }
-    dates.should == [Time.utc(2010, 11, 6, 5, 0, 0),
+    dates.each { |d| expect(d.utc?).to eq(true) }
+    expect(dates).to eq([Time.utc(2010, 11, 6, 5, 0, 0),
       Time.utc(2010, 11, 7, 5, 0, 0), Time.utc(2010, 11, 8, 5, 0, 0),
-      Time.utc(2010, 11, 9, 5, 0, 0)]
+      Time.utc(2010, 11, 9, 5, 0, 0)])
   end
 
   it 'works with a monthly rule iterating on UTC' do
@@ -238,11 +238,11 @@ describe IceCube::Schedule do
     schedule.add_recurrence_rule IceCube::Rule.monthly
     dates = schedule.first(10)
     dates.each do |d|
-      d.day.should == 24
-      d.hour.should == 15
-      d.min.should == 45
-      d.sec.should == 0
-      d.utc?.should be_true
+      expect(d.day).to eq(24)
+      expect(d.hour).to eq(15)
+      expect(d.min).to eq(45)
+      expect(d.sec).to eq(0)
+      expect(d.utc?).to be_true
     end
   end
 
@@ -251,7 +251,7 @@ describe IceCube::Schedule do
     rules = [IceCube::Rule.daily, IceCube::Rule.monthly, IceCube::Rule.yearly]
     rules.each { |r| schedule.add_recurrence_rule(r) }
     # pull the rules back out of the schedule and compare
-    schedule.rrules.should == rules
+    expect(schedule.rrules).to eq(rules)
   end
 
   it 'can retrieve exrules from a schedule' do
@@ -259,7 +259,7 @@ describe IceCube::Schedule do
     rules = [IceCube::Rule.daily, IceCube::Rule.monthly, IceCube::Rule.yearly]
     rules.each { |r| schedule.add_exception_rule(r) }
     # pull the rules back out of the schedule and compare
-    schedule.exrules.should == rules
+    expect(schedule.exrules).to eq(rules)
   end
 
   it 'can retrieve recurrence times from a schedule' do
@@ -267,7 +267,7 @@ describe IceCube::Schedule do
     times = [Time.now, Time.now + 5, Time.now + 10]
     times.each { |d| schedule.add_recurrence_time(d) }
     # pull the dates back out of the schedule and compare
-    schedule.rtimes.should == times
+    expect(schedule.rtimes).to eq(times)
   end
 
   it 'can retrieve exception_times from a schedule' do
@@ -275,7 +275,7 @@ describe IceCube::Schedule do
     times = [Time.now, Time.now + 5, Time.now + 10]
     times.each { |d| schedule.add_exception_time(d) }
     # pull the dates back out of the schedule and compare
-    schedule.extimes.should == times
+    expect(schedule.extimes).to eq(times)
   end
 
   it 'can reuse the same rule' do
@@ -285,7 +285,7 @@ describe IceCube::Schedule do
     result1 = schedule.first(10)
     rule.day(:monday)
     # check to make sure the change affected the rule
-    schedule.first(10).should_not == result1
+    expect(schedule.first(10)).not_to eq(result1)
   end
 
   it 'ensures that month of year (3) is march' do
@@ -295,7 +295,7 @@ describe IceCube::Schedule do
     schedule2 = IceCube::Schedule.new(DAY)
     schedule2.add_recurrence_rule IceCube::Rule.daily.month_of_year(3)
 
-    schedule.first(10).should == schedule2.first(10)
+    expect(schedule.first(10)).to eq(schedule2.first(10))
   end
 
   it 'ensures that day of week (1) is monday' do
@@ -305,7 +305,7 @@ describe IceCube::Schedule do
     schedule2 = IceCube::Schedule.new(DAY)
     schedule2.add_recurrence_rule IceCube::Rule.daily.day(1)
 
-    schedule.first(10).should == schedule2.first(10)
+    expect(schedule.first(10)).to eq(schedule2.first(10))
   end
 
   it 'should be able to find occurrences between two dates which are both in the future' do
@@ -313,7 +313,7 @@ describe IceCube::Schedule do
     schedule = IceCube::Schedule.new(start_time)
     schedule.add_recurrence_rule IceCube::Rule.daily
     dates = schedule.occurrences_between(start_time + IceCube::ONE_DAY * 2, start_time + IceCube::ONE_DAY * 4)
-    dates.should == [start_time + IceCube::ONE_DAY * 2, start_time + IceCube::ONE_DAY * 3, start_time + IceCube::ONE_DAY * 4]
+    expect(dates).to eq([start_time + IceCube::ONE_DAY * 2, start_time + IceCube::ONE_DAY * 3, start_time + IceCube::ONE_DAY * 4])
   end
 
   it 'should use start date on a bi-weekly recurrence pattern to find the occurrences_between when interval > 1' do
@@ -323,42 +323,42 @@ describe IceCube::Schedule do
     schedule.add_recurrence_rule IceCube::Rule.weekly(2).day(:sunday)
 
     occurrences = schedule.occurrences_between(Time.local(2012, 7, 7), Time.local(2012, 7, 9))
-    occurrences.should == [Time.local(2012, 7, 8)]
+    expect(occurrences).to eq([Time.local(2012, 7, 8)])
   end
 
   it 'should be able to tell us when there is at least one occurrence between two dates' do
     start_date = WEDNESDAY
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.weekly.day(:friday)
-    true.should == schedule.occurs_between?(start_date, start_date + IceCube::ONE_DAY * 3)
+    expect(true).to eq(schedule.occurs_between?(start_date, start_date + IceCube::ONE_DAY * 3))
   end
 
   it 'should be able to tell us when there is no occurrence between two dates' do
     start_date = WEDNESDAY
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.weekly.day(:friday)
-    false.should == schedule.occurs_between?(start_date, start_date + IceCube::ONE_DAY)
+    expect(false).to eq(schedule.occurs_between?(start_date, start_date + IceCube::ONE_DAY))
   end
 
   it 'should be able to get back rdates from a schedule' do
     schedule = IceCube::Schedule.new DAY
     schedule.add_recurrence_time DAY
     schedule.add_recurrence_time(DAY + 2)
-    schedule.rtimes.should == [DAY, DAY + 2]
+    expect(schedule.rtimes).to eq([DAY, DAY + 2])
   end
 
   it 'should be able to get back exception times from a schedule' do
     schedule = IceCube::Schedule.new DAY
     schedule.add_exception_time DAY
     schedule.add_exception_time(DAY + 2)
-    schedule.extimes.should == [DAY, DAY + 2]
+    expect(schedule.extimes).to eq([DAY, DAY + 2])
   end
 
   it 'should allow calling of .first on a schedule with no arguments' do
     start_time = Time.now
     schedule = IceCube::Schedule.new(start_time)
     schedule.add_recurrence_time start_time
-    schedule.first.should == start_time
+    expect(schedule.first).to eq(start_time)
   end
 
   it 'should be able to ignore nil dates that are inserted as part of a collection to add_recurrence_time' do
@@ -367,21 +367,21 @@ describe IceCube::Schedule do
     schedule.add_recurrence_time start_time
     schedule.add_recurrence_time start_time + IceCube::ONE_DAY
     schedule.add_recurrence_time nil
-    schedule.all_occurrences.should == [start_time, start_time + IceCube::ONE_DAY]
+    expect(schedule.all_occurrences).to eq([start_time, start_time + IceCube::ONE_DAY])
   end
 
   it 'should be able to use all_occurrences with no rules' do
     start_time = Time.now
     schedule = IceCube::Schedule.new(start_time)
     schedule.add_recurrence_time start_time
-    lambda do
-      schedule.all_occurrences.should == [start_time]
-    end.should_not raise_error
+    expect do
+      expect(schedule.all_occurrences).to eq([start_time])
+    end.not_to raise_error
   end
 
   it 'should use occurs_at? when calling occurring_at? with no duration' do
     schedule = IceCube::Schedule.new
-    schedule.should_receive(:occurs_at?)
+    expect(schedule).to receive(:occurs_at?)
     schedule.occurring_at?(Time.now)
   end
 
@@ -390,7 +390,7 @@ describe IceCube::Schedule do
     start_time = Time.local 2010, 5, 6, 10, 0, 0
     schedule = IceCube::Schedule.new(start_time, :duration => 3600)
     schedule.add_recurrence_rule IceCube::Rule.daily
-    schedule.occurring_at?(Time.local(2010, 5, 6, 10, 30, 0)).should be_true #true
+    expect(schedule.occurring_at?(Time.local(2010, 5, 6, 10, 30, 0))).to be_true #true
   end
 
   it 'should be able to specify a duration on a schedule and use occurring_at? on that schedule
@@ -398,8 +398,8 @@ describe IceCube::Schedule do
     start_time = Time.local 2010, 5, 6, 10, 0, 0
     schedule = IceCube::Schedule.new(start_time, :duration => 3600)
     schedule.add_recurrence_rule IceCube::Rule.daily
-    schedule.occurring_at?(Time.local(2010, 5, 6, 9, 59, 0)).should be_false
-    schedule.occurring_at?(Time.local(2010, 5, 6, 11, 0, 0)).should be_false
+    expect(schedule.occurring_at?(Time.local(2010, 5, 6, 9, 59, 0))).to be_false
+    expect(schedule.occurring_at?(Time.local(2010, 5, 6, 11, 0, 0))).to be_false
   end
 
   it 'should be able to specify a duration on a schedule and use occurring_at? on that schedule
@@ -407,8 +407,8 @@ describe IceCube::Schedule do
     start_time = Time.local 2010, 5, 6, 10, 0, 0
     schedule = IceCube::Schedule.new(start_time, :duration => 3600)
     schedule.add_recurrence_rule IceCube::Rule.daily
-    schedule.occurring_at?(Time.local(2010, 5, 6, 10, 0, 0)).should be_true
-    schedule.occurring_at?(Time.local(2010, 5, 6, 10, 59, 59)).should be_true
+    expect(schedule.occurring_at?(Time.local(2010, 5, 6, 10, 0, 0))).to be_true
+    expect(schedule.occurring_at?(Time.local(2010, 5, 6, 10, 59, 59))).to be_true
   end
 
   it 'should be able to explicity remove a certain minute from a duration' do
@@ -416,9 +416,9 @@ describe IceCube::Schedule do
     schedule = IceCube::Schedule.new(start_time, :duration => 3600)
     schedule.add_recurrence_rule IceCube::Rule.daily
     schedule.add_exception_time Time.local(2010, 5, 6, 10, 21, 30)
-    schedule.occurring_at?(Time.local(2010, 5, 6, 10, 21, 29)).should be_true
-    schedule.occurring_at?(Time.local(2010, 5, 6, 10, 21, 30)).should be_false
-    schedule.occurring_at?(Time.local(2010, 5, 6, 10, 21, 31)).should be_true
+    expect(schedule.occurring_at?(Time.local(2010, 5, 6, 10, 21, 29))).to be_true
+    expect(schedule.occurring_at?(Time.local(2010, 5, 6, 10, 21, 30))).to be_false
+    expect(schedule.occurring_at?(Time.local(2010, 5, 6, 10, 21, 31))).to be_true
   end
 
   it 'should be able to specify an end time for the schedule' do
@@ -426,7 +426,7 @@ describe IceCube::Schedule do
     end_time = DAY + IceCube::ONE_DAY * 2
     schedule = IceCube::Schedule.new(start_time)
     schedule.add_recurrence_rule IceCube::Rule.daily.until(end_time)
-    schedule.all_occurrences.should == [DAY, DAY + 1*IceCube::ONE_DAY, DAY + 2*IceCube::ONE_DAY]
+    expect(schedule.all_occurrences).to eq([DAY, DAY + 1*IceCube::ONE_DAY, DAY + 2*IceCube::ONE_DAY])
   end
 
   it 'should be able to specify an end time for the schedule and only get those on .first' do
@@ -434,11 +434,11 @@ describe IceCube::Schedule do
     # ensure proper response without the end time
     schedule = IceCube::Schedule.new(start_time)
     schedule.add_recurrence_rule IceCube::Rule.daily
-    schedule.first(5).should == [DAY, DAY + 1*IceCube::ONE_DAY, DAY + 2*IceCube::ONE_DAY, DAY + 3*IceCube::ONE_DAY, DAY + 4*IceCube::ONE_DAY]
+    expect(schedule.first(5)).to eq([DAY, DAY + 1*IceCube::ONE_DAY, DAY + 2*IceCube::ONE_DAY, DAY + 3*IceCube::ONE_DAY, DAY + 4*IceCube::ONE_DAY])
     # and then ensure that with the end time it stops it at the right day
     schedule = IceCube::Schedule.new(start_time)
     schedule.add_recurrence_rule IceCube::Rule.daily.until(DAY + IceCube::ONE_DAY * 2 + 1)
-    schedule.first(5).should == [DAY, DAY + 1 * IceCube::ONE_DAY, DAY + 2 * IceCube::ONE_DAY]
+    expect(schedule.first(5)).to eq([DAY, DAY + 1 * IceCube::ONE_DAY, DAY + 2 * IceCube::ONE_DAY])
   end
 
   it 'should be able to specify an end date and go to/from yaml' do
@@ -447,7 +447,7 @@ describe IceCube::Schedule do
     schedule = IceCube::Schedule.new(start_time, :end_time => end_time)
     schedule.add_recurrence_rule IceCube::Rule.daily
     schedule2 = IceCube::Schedule.from_yaml schedule.to_yaml
-    schedule2.end_time.should == end_time
+    expect(schedule2.end_time).to eq(end_time)
   end
 
   it 'should be able to specify an end date for the schedule and only get those on .occurrences_between' do
@@ -456,7 +456,7 @@ describe IceCube::Schedule do
     schedule = IceCube::Schedule.new(start_time)
     schedule.add_recurrence_rule IceCube::Rule.daily.until(end_time)
     expectation = [DAY, DAY + IceCube::ONE_DAY, DAY + 2*IceCube::ONE_DAY]
-    schedule.occurrences_between(start_time - IceCube::ONE_DAY, start_time + 4 * IceCube::ONE_DAY).should == expectation
+    expect(schedule.occurrences_between(start_time - IceCube::ONE_DAY, start_time + 4 * IceCube::ONE_DAY)).to eq(expectation)
   end
 
   it 'should be able to specify an end date for the schedule and only get those on .occurrences' do
@@ -465,7 +465,7 @@ describe IceCube::Schedule do
     schedule = IceCube::Schedule.new(start_time)
     schedule.add_recurrence_rule IceCube::Rule.daily.until(end_time)
     expectation = [DAY, DAY + IceCube::ONE_DAY, DAY + 2*IceCube::ONE_DAY]
-    schedule.occurrences(start_time + 4 * IceCube::ONE_DAY).should == expectation
+    expect(schedule.occurrences(start_time + 4 * IceCube::ONE_DAY)).to eq(expectation)
   end
 
   it 'should be able to work with an end date and .occurs_at' do
@@ -473,7 +473,7 @@ describe IceCube::Schedule do
     end_time = DAY + IceCube::ONE_DAY * 2
     schedule = IceCube::Schedule.new(start_time)
     schedule.add_recurrence_rule IceCube::Rule.daily.until(end_time)
-    schedule.occurs_at?(DAY + 4*IceCube::ONE_DAY).should be_false # out of range
+    expect(schedule.occurs_at?(DAY + 4*IceCube::ONE_DAY)).to be_false # out of range
   end
 
   it 'should be able to work with an end date and .occurring_at' do
@@ -481,8 +481,8 @@ describe IceCube::Schedule do
     end_time = DAY + IceCube::ONE_DAY * 2
     schedule = IceCube::Schedule.new(start_time, :duration => 20)
     schedule.add_recurrence_rule IceCube::Rule.daily.until(end_time)
-    schedule.occurring_at?((DAY + 2*IceCube::ONE_DAY + 10)).should be_true # in range
-    schedule.occurring_at?((DAY + 4*IceCube::ONE_DAY + 10)).should be_false # out of range
+    expect(schedule.occurring_at?((DAY + 2*IceCube::ONE_DAY + 10))).to be_true # in range
+    expect(schedule.occurring_at?((DAY + 4*IceCube::ONE_DAY + 10))).to be_false # out of range
   end
 
   it 'should not create an infinite loop crossing over february - github issue 6' do
@@ -494,69 +494,69 @@ describe IceCube::Schedule do
   it 'should be able to exist on the 28th of each month crossing over february - github issue 6a' do
     schedule = IceCube::Schedule.new(Time.local(2010, 1, 28))
     schedule.add_recurrence_rule IceCube::Rule.monthly
-    schedule.first(3).should == [Time.local(2010, 1, 28), Time.local(2010, 2, 28), Time.local(2010, 3, 28)]
+    expect(schedule.first(3)).to eq([Time.local(2010, 1, 28), Time.local(2010, 2, 28), Time.local(2010, 3, 28)])
   end
 
   it 'should be able to exist on the 29th of each month crossing over february - github issue 6a' do
     schedule = IceCube::Schedule.new(Time.zone.local(2010, 1, 29))
     schedule.add_recurrence_rule IceCube::Rule.monthly
-    schedule.first(3).should == [Time.zone.local(2010, 1, 29), Time.zone.local(2010, 2, 28), Time.zone.local(2010, 3, 29)]
+    expect(schedule.first(3)).to eq([Time.zone.local(2010, 1, 29), Time.zone.local(2010, 2, 28), Time.zone.local(2010, 3, 29)])
   end
 
   it 'should be able to exist on the 30th of each month crossing over february - github issue 6a' do
     schedule = IceCube::Schedule.new(Time.zone.local(2010, 1, 30))
     schedule.add_recurrence_rule IceCube::Rule.monthly
-    schedule.first(3).should == [Time.zone.local(2010, 1, 30), Time.zone.local(2010, 2, 28), Time.zone.local(2010, 3, 30)]
+    expect(schedule.first(3)).to eq([Time.zone.local(2010, 1, 30), Time.zone.local(2010, 2, 28), Time.zone.local(2010, 3, 30)])
   end
 
   it 'should be able to exist ont he 31st of each month crossing over february - github issue 6a' do
     schedule = IceCube::Schedule.new(Time.zone.local(2010, 1, 31))
     schedule.add_recurrence_rule IceCube::Rule.monthly
-    schedule.first(3).should == [Time.zone.local(2010, 1, 31), Time.zone.local(2010, 2, 28), Time.zone.local(2010, 3, 31)]
+    expect(schedule.first(3)).to eq([Time.zone.local(2010, 1, 31), Time.zone.local(2010, 2, 28), Time.zone.local(2010, 3, 31)])
   end
 
   it 'should deal with a yearly rule that has februaries with different mdays' do
     schedule = IceCube::Schedule.new(Time.local(2008, 2, 29))
     schedule.add_recurrence_rule IceCube::Rule.yearly
-    schedule.first(3).should == [Time.local(2008, 2, 29), Time.local(2009, 2, 28), Time.local(2010, 2, 28)]
+    expect(schedule.first(3)).to eq([Time.local(2008, 2, 29), Time.local(2009, 2, 28), Time.local(2010, 2, 28)])
   end
 
   it 'should work with every other month even when the day of the month iterating on does not exist' do
     schedule = IceCube::Schedule.new(Time.zone.local(2010, 1, 31))
     schedule.add_recurrence_rule IceCube::Rule.monthly(2)
-    schedule.first(6).should == [Time.zone.local(2010, 1, 31), Time.zone.local(2010, 3, 31), Time.zone.local(2010, 5, 31), Time.zone.local(2010, 7, 31), Time.zone.local(2010, 9, 30), Time.zone.local(2010, 11, 30)]
+    expect(schedule.first(6)).to eq([Time.zone.local(2010, 1, 31), Time.zone.local(2010, 3, 31), Time.zone.local(2010, 5, 31), Time.zone.local(2010, 7, 31), Time.zone.local(2010, 9, 30), Time.zone.local(2010, 11, 30)])
   end
 
   it 'should be able to go into february and stay on the same day' do
     schedule = IceCube::Schedule.new(Time.local(2010, 1, 5))
     schedule.add_recurrence_rule IceCube::Rule.monthly
-    schedule.first(2).should == [Time.local(2010, 1, 5), Time.local(2010, 2, 5)]
+    expect(schedule.first(2)).to eq([Time.local(2010, 1, 5), Time.local(2010, 2, 5)])
   end
 
   it 'should be able to know when to stop with an end date and a rule that misses a few times' do
     schedule = IceCube::Schedule.new(Time.local(2010, 2, 29))
     schedule.add_recurrence_rule IceCube::Rule.yearly.until(Time.local(2010, 10, 30))
-    schedule.first(10).should == [Time.local(2010, 2, 29)]
+    expect(schedule.first(10)).to eq([Time.local(2010, 2, 29)])
   end
 
   it 'should be able to know when to stop with an end date and a rule that misses a few times' do
     schedule = IceCube::Schedule.new(Time.local(2010, 2, 29))
     schedule.add_recurrence_rule IceCube::Rule.yearly.until(Time.local(2010, 10, 30))
-    schedule.first(10).should == [Time.local(2010, 2, 29)]
+    expect(schedule.first(10)).to eq([Time.local(2010, 2, 29)])
   end
 
   it 'should be able to know when to stop with an end date and a rule that misses a few times' do
     schedule = IceCube::Schedule.new(Time.local(2010, 2, 29))
     schedule.add_recurrence_rule IceCube::Rule.yearly.count(1)
-    schedule.first(10).should == [Time.local(2010, 2, 29)]
+    expect(schedule.first(10)).to eq([Time.local(2010, 2, 29)])
   end
 
   it 'should have some convenient aliases' do
     start_time = Time.now
     schedule = IceCube::Schedule.new(start_time)
 
-    schedule.start_time.should == schedule.start_time
-    schedule.end_time.should == schedule.end_time
+    expect(schedule.start_time).to eq(schedule.start_time)
+    expect(schedule.end_time).to eq(schedule.end_time)
   end
 
   it 'should have some convenient alias for rrules' do
@@ -564,7 +564,7 @@ describe IceCube::Schedule do
     daily = IceCube::Rule.daily; monthly = IceCube::Rule.monthly
     schedule.add_recurrence_rule daily
     schedule.rrule monthly
-    schedule.rrules.should == [daily, monthly]
+    expect(schedule.rrules).to eq([daily, monthly])
   end
 
   it 'should have some convenient alias for exrules' do
@@ -572,29 +572,29 @@ describe IceCube::Schedule do
     daily = IceCube::Rule.daily; monthly = IceCube::Rule.monthly
     schedule.add_exception_rule daily
     schedule.exrule monthly
-    schedule.exrules.should == [daily, monthly]
+    expect(schedule.exrules).to eq([daily, monthly])
   end
 
   it 'should have some convenient alias for recurrence_times' do
     schedule = IceCube::Schedule.new(Time.now)
     schedule.add_recurrence_time Time.local(2010, 8, 13)
     schedule.rtime Time.local(2010, 8, 14)
-    schedule.rtimes.should == [Time.local(2010, 8, 13), Time.local(2010, 8, 14)]
+    expect(schedule.rtimes).to eq([Time.local(2010, 8, 13), Time.local(2010, 8, 14)])
   end
 
   it 'should have some convenient alias for extimes' do
     schedule = IceCube::Schedule.new(Time.now)
     schedule.add_exception_time Time.local(2010, 8, 13)
     schedule.extime Time.local(2010, 8, 14)
-    schedule.extimes.should == [Time.local(2010, 8, 13), Time.local(2010, 8, 14)]
+    expect(schedule.extimes).to eq([Time.local(2010, 8, 13), Time.local(2010, 8, 14)])
   end
 
   it 'should be able to have a rule and an exrule' do
     schedule = IceCube::Schedule.new(Time.local(2010, 8, 27, 10))
     schedule.rrule IceCube::Rule.daily
     schedule.exrule IceCube::Rule.daily.day(:friday)
-    schedule.occurs_on?(Date.new(2010, 8, 27)).should be_false
-    schedule.occurs_on?(Date.new(2010, 8, 28)).should be_true
+    expect(schedule.occurs_on?(Date.new(2010, 8, 27))).to be_false
+    expect(schedule.occurs_on?(Date.new(2010, 8, 28))).to be_true
   end
 
   it 'should always generate the correct number of days for .first' do
@@ -602,9 +602,9 @@ describe IceCube::Schedule do
     r = IceCube::Rule.weekly(3).day(:monday, :wednesday, :friday)
     s.add_recurrence_rule(r)
     # test sizes
-    s.first(3).size.should == 3
-    s.first(4).size.should == 4
-    s.first(5).size.should == 5
+    expect(s.first(3).size).to eq(3)
+    expect(s.first(4).size).to eq(4)
+    expect(s.first(5).size).to eq(5)
   end
 
 
@@ -619,7 +619,7 @@ describe IceCube::Schedule do
     schedule2 = IceCube::Schedule.from_yaml(schedule.to_yaml, :start_date_override => start_date_override)
     dates = schedule2.first(10)
     dates.each do |date|
-      date.sec.should == start_date_override.sec
+      expect(date.sec).to eq(start_date_override.sec)
     end
   end
 
@@ -633,32 +633,32 @@ describe IceCube::Schedule do
     schedule2 = IceCube::Schedule.from_hash(schedule.to_hash, :start_date_override => start_date_override)
     dates = schedule2.first(10)
     dates.each do |date|
-      date.sec.should == start_date_override.sec
+      expect(date.sec).to eq(start_date_override.sec)
     end
   end
 
   it 'should use current date as start date when invoked with a nil parameter' do
     schedule = IceCube::Schedule.new nil
-    (Time.now - schedule.start_time).should be < 100
+    expect(Time.now - schedule.start_time).to be < 100
   end
 
   it 'should be able to get the occurrence count for a rule' do
     rule = IceCube::Rule.daily.count(5)
-    rule.occurrence_count.should == 5
+    expect(rule.occurrence_count).to eq(5)
   end
 
   it 'should be able to remove a count validation from a rule' do
     rule = IceCube::Rule.daily.count(5)
     rule.count nil
-    rule.to_hash.should_not have_key(:count)
-    rule.occurrence_count.should be_nil
+    expect(rule.to_hash).not_to have_key(:count)
+    expect(rule.occurrence_count).to be_nil
   end
 
   it 'should be able to remove an until validation from a rule' do
     rule = IceCube::Rule.daily.until(Time.now + IceCube::ONE_DAY)
-    rule.to_hash[:until].should_not be_nil
+    expect(rule.to_hash[:until]).not_to be_nil
     rule.until nil
-    rule.to_hash.should_not have_key(:until)
+    expect(rule.to_hash).not_to have_key(:until)
   end
 
   it 'should not have ridiculous load times for minutely on next_occurrence (from sidetiq)' do
@@ -688,7 +688,7 @@ describe IceCube::Schedule do
       (yield).next_occurrence(Time.now)
     end
     total = Time.now - time
-    total.should be < 0.1
+    expect(total).to be < 0.1
   end
 
 end

--- a/spec/examples/minutely_rule_spec.rb
+++ b/spec/examples/minutely_rule_spec.rb
@@ -4,12 +4,12 @@ module IceCube
   describe MinutelyRule, 'interval validation' do
     it 'converts a string integer to an actual int when using the interval method' do
       rule = Rule.minutely.interval("2")
-      rule.validations_for(:interval).first.interval.should == 2
+      expect(rule.validations_for(:interval).first.interval).to eq(2)
     end
 
     it 'converts a string integer to an actual int when using the initializer' do
       rule = Rule.minutely("3")
-      rule.validations_for(:interval).first.interval.should == 3
+      expect(rule.validations_for(:interval).first.interval).to eq(3)
     end
 
     it 'raises an argument error when a bad value is passed' do

--- a/spec/examples/minutely_rule_spec.rb
+++ b/spec/examples/minutely_rule_spec.rb
@@ -32,29 +32,29 @@ module IceCube
       schedule = double(start_time: t0 = Time.now)
       rule = Rule.minutely(7)
       rule.interval(5)
-      rule.next_time(t0 + 1, schedule, nil).should == t0 + 5 * IceCube::ONE_MINUTE
+      expect(rule.next_time(t0 + 1, schedule, nil)).to eq(t0 + 5 * IceCube::ONE_MINUTE)
     end
 
     it 'should work across DST start hour' do
       std_end = Time.local(2013, 3, 10, 1, 59, 0)
       schedule = Schedule.new(std_end)
       schedule.add_recurrence_rule Rule.minutely
-      schedule.first(3).should == [
+      expect(schedule.first(3)).to eq([
         std_end,
         std_end + ONE_MINUTE,
         std_end + ONE_MINUTE * 2
-      ]
+      ])
     end
 
     it 'should not skip DST end hour' do
       std_start = Time.local(2013, 11, 3, 1, 0, 0)
       schedule = Schedule.new(std_start - 60)
       schedule.add_recurrence_rule Rule.minutely
-      schedule.first(3).should == [
+      expect(schedule.first(3)).to eq([
         std_start - ONE_MINUTE,
         std_start,
         std_start + ONE_MINUTE
-      ]
+      ])
     end
 
     it 'should produce the correct days for @interval = 3' do
@@ -64,14 +64,14 @@ module IceCube
       schedule.add_recurrence_rule Rule.hourly(3)
       #check assumption (3) -- (1) 2 (3) 4 (5) 6
       dates = schedule.first(3)
-      dates.size.should == 3
-      dates.should == [DAY, DAY + 3 * ONE_HOUR, DAY + 6 * ONE_HOUR]
+      expect(dates.size).to eq(3)
+      expect(dates).to eq([DAY, DAY + 3 * ONE_HOUR, DAY + 6 * ONE_HOUR])
     end
 
     it 'should produce the correct minutes starting with an offset' do
       schedule = Schedule.new Time.new(2013, 11, 1, 1, 3, 0)
       schedule.rrule Rule.minutely(5)
-      schedule.next_occurrence(Time.new(2013, 11, 1, 1, 4, 0)).should == Time.new(2013, 11, 1, 1, 8, 0)
+      expect(schedule.next_occurrence(Time.new(2013, 11, 1, 1, 4, 0))).to eq(Time.new(2013, 11, 1, 1, 8, 0))
     end
 
   end

--- a/spec/examples/monthly_rule_spec.rb
+++ b/spec/examples/monthly_rule_spec.rb
@@ -36,48 +36,48 @@ module IceCube
       schedule = double(start_time: t0 = Time.utc(2013, 5, 17))
       rule = Rule.monthly(3)
       rule.interval(1)
-      rule.next_time(t0 + 1, schedule, nil).should == t0 + 31.days
+      expect(rule.next_time(t0 + 1, schedule, nil)).to eq(t0 + 31.days)
     end
 
     it 'should produce the correct number of days for @interval = 1' do
       schedule = Schedule.new(t0 = Time.now)
       schedule.add_recurrence_rule Rule.monthly
       #check assumption
-      schedule.occurrences(t0 + 50 * ONE_DAY).size.should == 2
+      expect(schedule.occurrences(t0 + 50 * ONE_DAY).size).to eq(2)
     end
 
     it 'should produce the correct number of days for @interval = 2' do
       schedule = Schedule.new(t0 = Time.now)
       schedule.add_recurrence_rule Rule.monthly(2)
-      schedule.occurrences(t0 + 50 * ONE_DAY).size.should == 1
+      expect(schedule.occurrences(t0 + 50 * ONE_DAY).size).to eq(1)
     end
 
     it 'should produce the correct number of days for @interval = 1 with only the 1st and 15th' do
       schedule = Schedule.new(t0 = Time.utc(2010, 1, 1))
       schedule.add_recurrence_rule Rule.monthly.day_of_month(1, 15)
       #check assumption (1) (15) (1) (15)
-      schedule.occurrences(t0 + 50 * ONE_DAY).map(&:day).should == [1, 15, 1, 15]
+      expect(schedule.occurrences(t0 + 50 * ONE_DAY).map(&:day)).to eq([1, 15, 1, 15])
     end
 
     it 'should produce the correct number of days for @interval = 1 with only the 1st and last' do
       schedule = Schedule.new(t0 = Time.utc(2010, 1, 1))
       schedule.add_recurrence_rule Rule.monthly.day_of_month(1, -1)
       #check assumption (1) (31) (1)
-      schedule.occurrences(t0 + 60 * ONE_DAY).map(&:day).should == [1, 31, 1, 28, 1]
+      expect(schedule.occurrences(t0 + 60 * ONE_DAY).map(&:day)).to eq([1, 31, 1, 28, 1])
     end
 
     it 'should produce the correct number of days for @interval = 1 with only the first mondays' do
       schedule = Schedule.new(t0 = Time.utc(2010, 1, 1))
       schedule.add_recurrence_rule Rule.monthly.day_of_week(:monday => [1])
       #check assumption (month 1 monday) (month 2 monday)
-      schedule.occurrences(t0 + 50 * ONE_DAY).size.should == 2
+      expect(schedule.occurrences(t0 + 50 * ONE_DAY).size).to eq(2)
     end
 
     it 'should produce the correct number of days for @interval = 1 with only the last mondays' do
       schedule = Schedule.new(t0 = Time.utc(2010, 1, 1))
       schedule.add_recurrence_rule Rule.monthly.day_of_week(:monday => [-1])
       #check assumption (month 1 monday)
-      schedule.occurrences(t0 + 40 * ONE_DAY).size.should == 1
+      expect(schedule.occurrences(t0 + 40 * ONE_DAY).size).to eq(1)
     end
 
     it 'should produce the correct number of days for @interval = 1 with only the first and last mondays' do
@@ -86,7 +86,7 @@ module IceCube
       schedule = Schedule.new(t0)
       schedule.add_recurrence_rule Rule.monthly.day_of_week(:monday => [1, -2])
       #check assumption (12 months - 2 dates each)
-      schedule.occurrences(t1).size.should == 24
+      expect(schedule.occurrences(t1).size).to eq(24)
     end
 
     [:sunday, :monday, :tuesday, :wednesday, :thursday, :friday, :saturday].each_with_index do |weekday, wday|
@@ -99,21 +99,21 @@ module IceCube
         it "should not skip a month when DST ends" do
           schedule.first(48).inject(nil) do |last_date, current_date|
             next current_date unless last_date
-            month_interval(current_date, last_date).should == 1
+            expect(month_interval(current_date, last_date)).to eq(1)
           end
         end
 
         it "should not change day when DST ends" do
           schedule.first(48).inject(nil) do |last_date, current_date|
             next current_date unless last_date
-            current_date.wday.should == wday
+            expect(current_date.wday).to eq(wday)
           end
         end
 
         it "should not change hour when DST ends" do
           schedule.first(48).inject(nil) do |last_date, current_date|
             next current_date unless last_date
-            current_date.hour.should == 0
+            expect(current_date.hour).to eq(0)
           end
         end
       end
@@ -122,33 +122,33 @@ module IceCube
     it 'should produce dates on a monthly interval for the last day of the month' do
       schedule = Schedule.new(t0 = Time.utc(2010, 3, 31, 0, 0, 0))
       schedule.add_recurrence_rule Rule.monthly
-      schedule.first(10).should == [
+      expect(schedule.first(10)).to eq([
         Time.utc(2010,  3, 31, 0, 0, 0), Time.utc(2010,  4, 30, 0, 0, 0),
         Time.utc(2010,  5, 31, 0, 0, 0), Time.utc(2010,  6, 30, 0, 0, 0),
         Time.utc(2010,  7, 31, 0, 0, 0), Time.utc(2010,  8, 31, 0, 0, 0),
         Time.utc(2010,  9, 30, 0, 0, 0), Time.utc(2010, 10, 31, 0, 0, 0),
         Time.utc(2010, 11, 30, 0, 0, 0), Time.utc(2010, 12, 31, 0, 0, 0)
-      ]
+      ])
     end
 
     it 'should produce dates on a monthly interval for latter days in the month near February' do
       schedule = Schedule.new(t0 = Time.utc(2010, 1, 29, 0, 0, 0))
       schedule.add_recurrence_rule Rule.monthly
-      schedule.first(3).should == [
+      expect(schedule.first(3)).to eq([
         Time.utc(2010, 1, 29, 0, 0, 0),
         Time.utc(2010, 2, 28, 0, 0, 0),
         Time.utc(2010, 3, 29, 0, 0, 0)
-      ]
+      ])
     end
 
     it 'should restrict to available days of month when specified' do
       schedule = Schedule.new(t0 = Time.utc(2013,1,31))
       schedule.add_recurrence_rule Rule.monthly.day_of_month(31)
-      schedule.first(3).should == [
+      expect(schedule.first(3)).to eq([
         Time.utc(2013, 1, 31),
         Time.utc(2013, 3, 31),
         Time.utc(2013, 5, 31)
-      ]
+      ])
     end
 
     def month_interval(current_date, last_date)

--- a/spec/examples/monthly_rule_spec.rb
+++ b/spec/examples/monthly_rule_spec.rb
@@ -4,17 +4,17 @@ module IceCube
   describe MonthlyRule, 'interval validation' do
     it 'converts a string integer to an actual int when using the interval method' do
       rule = Rule.monthly.interval("2")
-      rule.validations_for(:interval).first.interval.should == 2
+      expect(rule.validations_for(:interval).first.interval).to eq(2)
     end
 
     it 'converts a string integer to an actual int when using the initializer' do
       rule = Rule.monthly("3")
-      rule.validations_for(:interval).first.interval.should == 3
+      expect(rule.validations_for(:interval).first.interval).to eq(3)
     end
 
     it 'converts a string integer to an actual int' do
       rule = Rule.monthly("1")
-      rule.instance_variable_get(:@interval).should == 1
+      expect(rule.instance_variable_get(:@interval)).to eq(1)
     end
 
     it 'raises an argument error when a bad value is passed' do

--- a/spec/examples/occurrence_spec.rb
+++ b/spec/examples/occurrence_spec.rb
@@ -6,9 +6,9 @@ describe Occurrence do
 
   it "reports as a Time" do
     occurrence = Occurrence.new(t0 = Time.now, t0 + 3600)
-    occurrence.class.name.should == 'Time'
-    occurrence.is_a?(Time).should be_true
-    occurrence.kind_of?(Time).should be_true
+    expect(occurrence.class.name).to eq('Time')
+    expect(occurrence.is_a?(Time)).to be_true
+    expect(occurrence.kind_of?(Time)).to be_true
   end
 
   describe :to_s do
@@ -16,7 +16,7 @@ describe Occurrence do
       start_time = Time.now
       occurrence = Occurrence.new(start_time)
 
-      occurrence.to_s.should == start_time.to_s
+      expect(occurrence.to_s).to eq(start_time.to_s)
     end
 
     it "looks like a range for a non-zero duration" do
@@ -24,7 +24,7 @@ describe Occurrence do
       end_time = start_time + ONE_HOUR
       occurrence = Occurrence.new(start_time, end_time)
 
-      occurrence.to_s.should == "#{start_time} - #{end_time}"
+      expect(occurrence.to_s).to eq("#{start_time} - #{end_time}")
     end
 
     it "accepts a format option to comply with ActiveSupport" do
@@ -40,7 +40,7 @@ describe Occurrence do
       start_time = Time.now
       occurrence = Occurrence.new(start_time)
 
-      occurrence.end_time.should == start_time
+      expect(occurrence.end_time).to eq(start_time)
     end
 
     it 'returns specified end_time' do
@@ -48,7 +48,7 @@ describe Occurrence do
       end_time = start_time + 3600
       occurrence = Occurrence.new(start_time, end_time)
 
-      occurrence.end_time.should == end_time
+      expect(occurrence.end_time).to eq(end_time)
     end
 
   end
@@ -60,12 +60,12 @@ describe Occurrence do
 
     it 'returns a time when adding' do
       new_time = occurrence + 60
-      new_time.should == start_time + 60
+      expect(new_time).to eq(start_time + 60)
     end
 
     it 'can get difference from a time' do
       difference = occurrence - (start_time - 60)
-      difference.should == 60
+      expect(difference).to eq(60)
     end
 
   end
@@ -79,14 +79,14 @@ describe Occurrence do
       occurrence = Occurrence.new(start_time, end_time)
 
       inclusion = occurrence.intersects? start_time + 1800
-      inclusion.should be_true
+      expect(inclusion).to be_true
     end
 
     it 'is false for a time outside the occurrence' do
       occurrence = Occurrence.new(start_time, end_time)
 
       inclusion = occurrence.intersects? start_time + 3601
-      inclusion.should be_false
+      expect(inclusion).to be_false
     end
 
     it 'is true for an intersecting occurrence' do
@@ -94,7 +94,7 @@ describe Occurrence do
       occurrence2 = Occurrence.new(start_time + 1, end_time + 1)
 
       inclusion = occurrence1.intersects? occurrence2
-      inclusion.should be_true
+      expect(inclusion).to be_true
     end
 
     it 'is false for a non-intersecting occurrence' do
@@ -102,55 +102,55 @@ describe Occurrence do
       occurrence2 = Occurrence.new(end_time)
 
       inclusion = occurrence1.intersects? occurrence2
-      inclusion.should be_false
+      expect(inclusion).to be_false
     end
   end
 
   describe :overnight? do
     it 'is false for a zero-length occurrence' do
       occurrence = Occurrence.new(Time.local(2013, 12, 24))
-      occurrence.overnight?.should be_false
+      expect(occurrence.overnight?).to be_false
     end
 
     it 'is false for a zero-length occurrence on the last day of a month' do
       occurrence = Occurrence.new(Time.local(2013, 3, 31))
-      occurrence.overnight?.should be_false
+      expect(occurrence.overnight?).to be_false
     end
 
     it 'is false for a duration within a single day' do
       t0 = Time.local(2013, 2, 24, 8, 0, 0)
       occurrence = Occurrence.new(t0, t0 + 3600)
-      occurrence.overnight?.should be_false
+      expect(occurrence.overnight?).to be_false
     end
 
     it 'is false for a duration that starts at midnight' do
       t0 = Time.local(2013, 2, 24, 0, 0, 0)
       occurrence = Occurrence.new(t0, t0 + 3600)
-      occurrence.overnight?.should be_false
+      expect(occurrence.overnight?).to be_false
     end
 
     it 'is false for a duration that starts at midnight on the last day of a month' do
       t0 = Time.local(2013, 3, 31, 0, 0, 0)
       occurrence = Occurrence.new(t0, t0 + 3600)
-      occurrence.overnight?.should be_false
+      expect(occurrence.overnight?).to be_false
     end
 
     it 'is false for a duration that ends at midnight' do
       t0 = Time.local(2013, 2, 24, 23, 0, 0)
       occurrence = Occurrence.new(t0, t0 + 3600)
-      occurrence.overnight?.should be_false
+      expect(occurrence.overnight?).to be_false
     end
 
     it 'is true for a duration that crosses midnight' do
       t0 = Time.local(2013, 2, 24, 23, 0, 0)
       occurrence = Occurrence.new(t0, t0 + 3601)
-      occurrence.overnight?.should be_true
+      expect(occurrence.overnight?).to be_true
     end
 
     it 'is true for a duration that crosses midnight on the last day of a month' do
       t0 = Time.local(2013, 3, 31, 23, 0, 0)
       occurrence = Occurrence.new(t0, t0 + 3601)
-      occurrence.overnight?.should be_true
+      expect(occurrence.overnight?).to be_true
     end
   end
 

--- a/spec/examples/recur_spec.rb
+++ b/spec/examples/recur_spec.rb
@@ -9,14 +9,14 @@ describe :remaining_occurrences do
     end_time = Time.local(start_time.year, start_time.month, start_time.day, 23, 59, 59)
     schedule = Schedule.new(start_time)
     schedule.add_recurrence_rule(Rule.hourly.until(end_time))
-    schedule.remaining_occurrences(start_time).size.should == 24 - schedule.start_time.hour
+    expect(schedule.remaining_occurrences(start_time).size).to eq(24 - schedule.start_time.hour)
   end
 
   it 'should get the proper ramining occurrences past the end of the year' do
     start_time = Time.now
     schedule = Schedule.new(start_time)
     schedule.add_recurrence_rule(Rule.hourly.until(start_time + ONE_DAY))
-    schedule.remaining_occurrences(start_time + 366 * ONE_DAY).size.should == 0
+    expect(schedule.remaining_occurrences(start_time + 366 * ONE_DAY).size).to eq(0)
   end
 
   it 'should raise an error if there is nothing to stop it' do
@@ -39,41 +39,41 @@ describe :occurring_between? do
   end
 
   it 'should affirm an occurrence that spans the range exactly' do
-    schedule.occurring_between?(start_time, end_time).should be_true
+    expect(schedule.occurring_between?(start_time, end_time)).to be_true
   end
 
   it 'should affirm a zero-length occurrence at the start of the range' do
     schedule.duration = 0
-    schedule.occurring_between?(start_time, start_time).should be_true
+    expect(schedule.occurring_between?(start_time, start_time)).to be_true
   end
 
   it 'should deny a zero-length occurrence at the end of the range' do
     schedule.duration = 0
-    schedule.occurring_between?(end_time, end_time).should be_false
+    expect(schedule.occurring_between?(end_time, end_time)).to be_false
   end
 
   it 'should affirm an occurrence entirely contained within the range' do
-    schedule.occurring_between?(start_time + 1, end_time - 1).should be_true
+    expect(schedule.occurring_between?(start_time + 1, end_time - 1)).to be_true
   end
 
   it 'should affirm an occurrence spanning across the start of the range' do
-    schedule.occurring_between?(start_time - 1, start_time + 1).should be_true
+    expect(schedule.occurring_between?(start_time - 1, start_time + 1)).to be_true
   end
 
   it 'should affirm an occurrence spanning across the end of the range' do
-    schedule.occurring_between?(end_time - 1, end_time + 1).should be_true
+    expect(schedule.occurring_between?(end_time - 1, end_time + 1)).to be_true
   end
 
   it 'should affirm an occurrence spanning across the range entirely' do
-    schedule.occurring_between?(start_time - 1, end_time + 1).should be_true
+    expect(schedule.occurring_between?(start_time - 1, end_time + 1)).to be_true
   end
 
   it 'should deny an occurrence before the range' do
-    schedule.occurring_between?(end_time + 1, end_time + 2).should be_false
+    expect(schedule.occurring_between?(end_time + 1, end_time + 2)).to be_false
   end
 
   it 'should deny an occurrence after the range' do
-    schedule.occurring_between?(start_time - 2, start_time - 1).should be_false
+    expect(schedule.occurring_between?(start_time - 2, start_time - 1)).to be_false
   end
 
 end
@@ -84,27 +84,27 @@ describe :next_occurrence do
     start_time = Time.local(2010, 10, 10, 10, 0, 0)
     schedule = Schedule.new(start_time, :end_time => start_time + 24 * ONE_HOUR)
     schedule.add_recurrence_rule(Rule.hourly)
-    schedule.next_occurrence(schedule.start_time).should == schedule.start_time + 1 * ONE_HOUR
+    expect(schedule.next_occurrence(schedule.start_time)).to eq(schedule.start_time + 1 * ONE_HOUR)
   end
 
   it 'should get the next occurrence past the end of the year' do
     start_time = Time.now
     schedule = Schedule.new(start_time, :end_time => start_time + 24 * ONE_HOUR)
     schedule.add_recurrence_rule(Rule.hourly)
-    schedule.next_occurrence(schedule.end_time + 366 * ONE_DAY).should == schedule.end_time + 366 * ONE_DAY + 1 * ONE_HOUR
+    expect(schedule.next_occurrence(schedule.end_time + 366 * ONE_DAY)).to eq(schedule.end_time + 366 * ONE_DAY + 1 * ONE_HOUR)
   end
 
   it 'should be able to use next_occurrence on a never-ending schedule' do
     schedule = Schedule.new(Time.now)
     schedule.add_recurrence_rule Rule.hourly
-    schedule.next_occurrence(schedule.start_time).should == schedule.start_time + ONE_HOUR
+    expect(schedule.next_occurrence(schedule.start_time)).to eq(schedule.start_time + ONE_HOUR)
   end
 
   it 'should get the next occurrence when a recurrence date is also added' do
     schedule = Schedule.new(Time.now)
     schedule.add_recurrence_time(schedule.start_time + 30 * ONE_MINUTE)
     schedule.add_recurrence_rule Rule.hourly
-    schedule.next_occurrence(schedule.start_time).should == schedule.start_time + 30 * ONE_MINUTE
+    expect(schedule.next_occurrence(schedule.start_time)).to eq(schedule.start_time + 30 * ONE_MINUTE)
   end
 
   it 'should get the next occurrence and ignore recurrence dates that are before the desired time' do
@@ -112,7 +112,7 @@ describe :next_occurrence do
     schedule.add_recurrence_time(schedule.start_time + 30 * ONE_MINUTE)
     schedule.add_recurrence_time(schedule.start_time - 30 * ONE_MINUTE)
     schedule.add_recurrence_rule Rule.hourly
-    schedule.next_occurrence(schedule.start_time).should == schedule.start_time + 30 * ONE_MINUTE
+    expect(schedule.next_occurrence(schedule.start_time)).to eq(schedule.start_time + 30 * ONE_MINUTE)
   end
 
 end
@@ -123,35 +123,35 @@ describe :next_occurrences do
     start_time = Time.local(2010, 1, 1, 10, 0, 0)
     schedule = Schedule.new(start_time, :end_time => start_time + ONE_HOUR * 24)
     schedule.add_recurrence_rule(Rule.hourly)
-    schedule.next_occurrences(3, start_time).should == [
+    expect(schedule.next_occurrences(3, start_time)).to eq([
       schedule.start_time + 1 * ONE_HOUR,
       schedule.start_time + 2 * ONE_HOUR,
-      schedule.start_time + 3 * ONE_HOUR]
+      schedule.start_time + 3 * ONE_HOUR])
   end
 
   it 'should get the next 3 occurrence past the end of the year' do
     schedule = Schedule.new(Time.now, :end_time => Time.now + ONE_HOUR * 24)
     schedule.add_recurrence_rule(Rule.hourly.until(Time.now + 365 * ONE_DAY))
-    schedule.next_occurrences(3, schedule.end_time + 366 * ONE_DAY).should == []
+    expect(schedule.next_occurrences(3, schedule.end_time + 366 * ONE_DAY)).to eq([])
   end
 
   it 'should be able to use next_occurrences on a never-ending schedule' do
     schedule = Schedule.new(Time.now)
     schedule.add_recurrence_rule Rule.hourly
-    schedule.next_occurrences(3, schedule.start_time).should == [
+    expect(schedule.next_occurrences(3, schedule.start_time)).to eq([
       schedule.start_time + 1 * ONE_HOUR,
       schedule.start_time + 2 * ONE_HOUR,
-      schedule.start_time + 3 * ONE_HOUR]
+      schedule.start_time + 3 * ONE_HOUR])
   end
 
   it 'should get the next 3 occurrences when a recurrence date is also added' do
     schedule = Schedule.new(Time.now)
     schedule.add_recurrence_rule Rule.hourly
     schedule.add_recurrence_time(schedule.start_time + 30 * ONE_MINUTE)
-    schedule.next_occurrences(3, schedule.start_time).should == [
+    expect(schedule.next_occurrences(3, schedule.start_time)).to eq([
       schedule.start_time + 30 * ONE_MINUTE,
       schedule.start_time + 1 * ONE_HOUR,
-      schedule.start_time + 2 * ONE_HOUR]
+      schedule.start_time + 2 * ONE_HOUR])
   end
 
   it 'should get the next 3 occurrences and ignore recurrence dates that are before the desired time' do
@@ -159,16 +159,16 @@ describe :next_occurrences do
     schedule.add_recurrence_time(schedule.start_time + 30 * ONE_MINUTE)
     schedule.add_recurrence_time(schedule.start_time - 30 * ONE_MINUTE)
     schedule.add_recurrence_rule Rule.hourly
-    schedule.next_occurrences(3, schedule.start_time).should == [
+    expect(schedule.next_occurrences(3, schedule.start_time)).to eq([
       schedule.start_time + 30 * ONE_MINUTE,
       schedule.start_time + ONE_HOUR,
-      schedule.start_time + ONE_HOUR * 2]
+      schedule.start_time + ONE_HOUR * 2])
   end
 
   it 'should generate the same comparable time objects (down to millisecond) on two runs' do
     schedule = Schedule.new Time.now
     schedule.rrule Rule.daily
-    schedule.next_occurrences(5).should == schedule.next_occurrences(5)
+    expect(schedule.next_occurrences(5)).to eq(schedule.next_occurrences(5))
   end
 
 end

--- a/spec/examples/regression_spec.rb
+++ b/spec/examples/regression_spec.rb
@@ -16,7 +16,7 @@ module IceCube
           schedule.add_recurrence_time Time.local(2011, 12, 3, 15, 0, 0)
           schedule.add_recurrence_time Time.local(2011, 12, 3, 10, 0, 0)
           schedule.add_recurrence_time Time.local(2011, 12, 4, 10, 0, 0)
-          schedule.occurs_at?(Time.local(2011, 12, 3, 15, 0, 0)).should be_true
+          expect(schedule.occurs_at?(Time.local(2011, 12, 3, 15, 0, 0))).to be_true
         end
 
         it 'should work well with occurrences_between [#33]' do
@@ -25,7 +25,7 @@ module IceCube
           schedule.add_recurrence_rule Rule.weekly.day(2).hour_of_day(15).minute_of_hour(0)
           schedule.add_exception_time Time.local(2011, 10, 13, 21)
           schedule.add_exception_time Time.local(2011, 10, 18, 21)
-          schedule.occurrences_between(Time.local(2012, 1, 1), Time.local(2012, 12, 1)).should be_an Array
+          expect(schedule.occurrences_between(Time.local(2012, 1, 1), Time.local(2012, 12, 1))).to be_an Array
         end
 
         it 'should work with all validation locks [#45]' do
@@ -33,13 +33,13 @@ module IceCube
           schedule.rrule Rule.monthly.
                              month_of_year(10).day_of_month(13).day(5).
                              hour_of_day(14).minute_of_hour(0).second_of_minute(0)
-          schedule.occurrences(Date.today >> 12).should be_an Array
+          expect(schedule.occurrences(Date.today >> 12)).to be_an Array
         end
 
         it 'should not regress [#40]' do
           schedule = Schedule.new(t0 = Time.local(2011, 11, 16, 11, 31, 58), :duration => 3600)
           schedule.add_recurrence_rule Rule.minutely(60).day(4).hour_of_day(14, 15, 16).minute_of_hour(0)
-          schedule.occurring_at?(Time.local(2011, 11, 17, 15, 30)).should be_false
+          expect(schedule.occurring_at?(Time.local(2011, 11, 17, 15, 30))).to be_false
         end
 
         it 'should not choke on parsing [#26]' do
@@ -51,15 +51,15 @@ module IceCube
         it 'should parse an old schedule properly' do
           file = File.read(File.dirname(__FILE__) + '/../data/issue40.yml')
           schedule = Schedule.from_yaml(file)
-          schedule.start_time.year.should == 2011
-          schedule.start_time.month.should == 11
-          schedule.start_time.day.should == 16
-          schedule.start_time.utc_offset.should == -5 * 3600
+          expect(schedule.start_time.year).to eq(2011)
+          expect(schedule.start_time.month).to eq(11)
+          expect(schedule.start_time.day).to eq(16)
+          expect(schedule.start_time.utc_offset).to eq(-5 * 3600)
 
-          schedule.duration.should == 3600
-          schedule.rrules.should == [
+          expect(schedule.duration).to eq(3600)
+          expect(schedule.rrules).to eq([
             Rule.minutely(60).day(4).hour_of_day(14, 15, 16).minute_of_hour(0)
-          ]
+          ])
         end
 
         it 'should handle a simple weekly schedule [#52]' do
@@ -67,52 +67,52 @@ module IceCube
           t1 = Time.new(2012, 1, 1, 18, 0, 0)
           schedule = Schedule.new(t0)
           schedule.add_recurrence_rule Rule.weekly(1).day(4).until(t1)
-          schedule.all_occurrences.should == [
+          expect(schedule.all_occurrences).to eq([
             Time.new(2011, 12,  1, 18),
             Time.new(2011, 12,  8, 18),
             Time.new(2011, 12, 15, 18),
             Time.new(2011, 12, 22, 18),
             Time.new(2011, 12, 29, 18)
-          ]
+          ])
         end
 
         it 'should produce all occurrences between dates, not breaking on exceptions [#82]' do
           schedule = Schedule.new(t0 = Time.new(2012, 5, 1))
           schedule.add_recurrence_rule Rule.daily.day(:sunday, :tuesday, :wednesday, :thursday, :friday, :saturday)
           times = schedule.occurrences_between(Time.new(2012, 5, 19), Time.new(2012, 5, 24))
-          times.should == [
+          expect(times).to eq([
             Time.new(2012, 5, 19),
             Time.new(2012, 5, 20),
             # No 21st
             Time.new(2012, 5, 22),
             Time.new(2012, 5, 23),
             Time.new(2012, 5, 24)
-          ]
+          ])
         end
 
         it 'should be able to use count with occurrences_between falling over counts last occurrence [#54]' do
           schedule = Schedule.new(t0 = Time.now)
           schedule.add_recurrence_rule Rule.daily.count(5)
-          schedule.occurrences_between(t0, t0 + ONE_WEEK).count.should == 5
-          schedule.occurrences_between(t0 + ONE_WEEK, t0 + 2 * ONE_WEEK).count.should == 0
+          expect(schedule.occurrences_between(t0, t0 + ONE_WEEK).count).to eq(5)
+          expect(schedule.occurrences_between(t0 + ONE_WEEK, t0 + 2 * ONE_WEEK).count).to eq(0)
         end
 
         it 'should produce occurrences regardless of time being specified [#81]' do
           schedule = Schedule.new(t0 = Time.new(2012, 5, 1))
           schedule.add_recurrence_rule Rule.daily.hour_of_day(8)
           times = schedule.occurrences_between(Time.new(2012, 05, 20), Time.new(2012, 05, 22))
-          times.should == [
+          expect(times).to eq([
             Time.new(2012, 5, 20, 8, 0, 0),
             Time.new(2012, 5, 21, 8, 0, 0)
-          ]
+          ])
         end
 
         it 'should not include exception times due to rounding errors [#83]' do
           schedule = Schedule.new(t0 = Time.new(2012, 12, 21, 21, 12, 21.212121))
           schedule.rrule Rule.daily
           schedule.extime((t0 + ONE_DAY).round)
-          schedule.first(2)[0].should == t0
-          schedule.first(2)[1].should == t0 + 2 * ONE_DAY
+          expect(schedule.first(2)[0]).to eq(t0)
+          expect(schedule.first(2)[1]).to eq(t0 + 2 * ONE_DAY)
         end
 
         it 'should return true if a recurring schedule occurs_between? a time range [#88]' do
@@ -121,7 +121,7 @@ module IceCube
           schedule.add_recurrence_rule Rule.weekly
           t0 = Time.new(2012, 7, 14, 9)
           t1 = Time.new(2012, 7, 14, 11)
-          schedule.occurring_between?(t0, t1).should be_true
+          expect(schedule.occurring_between?(t0, t1)).to be_true
         end
 
         require 'active_support/time'
@@ -154,7 +154,7 @@ module IceCube
           :extimes: []
           EOS
           times = schedule.occurrences(Date.new(2013, 07, 13).to_time)
-          times.detect { |o| Date.new(o.year, o.month, o.day) == Date.new(2013, 3, 31) }.should be_true
+          expect(times.detect { |o| Date.new(o.year, o.month, o.day) == Date.new(2013, 3, 31) }).to be_true
         end
 
         it "failing spec for hanging on DST boundary [#98]" do
@@ -162,7 +162,7 @@ module IceCube
           t0 = Time.zone.parse("Sun, 31 Mar 2013 00:00:00 GMT +00:00")
           schedule = Schedule.new(t0)
           schedule.add_recurrence_rule Rule.monthly
-          schedule.next_occurrence(t0).should == Time.zone.local(2013, 4, 30)
+          expect(schedule.next_occurrence(t0)).to eq(Time.zone.local(2013, 4, 30))
         end
 
         it 'should exclude a date from a weekly schedule [#55]' do
@@ -172,7 +172,7 @@ module IceCube
             schedule.add_recurrence_rule Rule.weekly.day(:tuesday, :thursday)
             schedule.add_exception_time t0
           end
-          schedule.first.should == Time.zone.local(2011, 12, 29, 14)
+          expect(schedule.first).to eq(Time.zone.local(2011, 12, 29, 14))
         end
 
         it 'should not raise an exception after setting the rule until to nil' do
@@ -192,38 +192,38 @@ module IceCube
           schedule.duration = 3600
           t1 = Time.new(2012, 10, 20, 0, 0, 0)
           t2 = Time.new(2012, 10, 20, 23, 59, 59)
-          schedule.occurrences_between(t1, t2).first.should == t1
+          expect(schedule.occurrences_between(t1, t2).first).to eq(t1)
         end
 
         it 'should return next_occurrence in utc if start_time is utc [#115]' do
           schedule = Schedule.new(t0 = Time.utc(2012, 10, 10, 20, 15, 0))
           schedule.rrule Rule.daily
-          schedule.next_occurrence.should be_utc
+          expect(schedule.next_occurrence).to be_utc
         end
 
         it 'should return next_occurrence in local if start_time is local [#115]' do
           schedule = Schedule.new Time.new(2012, 10, 10, 20, 15, 0)
           schedule.rrule Rule.daily
-          schedule.next_occurrence.should_not be_utc
+          expect(schedule.next_occurrence).not_to be_utc
         end
 
         it 'should return next_occurrence in local by default [#115]' do
           schedule = Schedule.new
           schedule.rrule Rule.daily
-          schedule.next_occurrence.should_not be_utc
+          expect(schedule.next_occurrence).not_to be_utc
         end
 
         it 'should include occurrences on until _date_ [#118]' do
           schedule = Schedule.new Time.new(2012, 4, 27)
           schedule.rrule Rule.daily.hour_of_day(12).until(Date.new(2012, 4, 28))
-          schedule.all_occurrences.should == [Time.new(2012, 4, 27, 12), Time.new(2012, 4, 28, 12)]
+          expect(schedule.all_occurrences).to eq([Time.new(2012, 4, 27, 12), Time.new(2012, 4, 28, 12)])
         end
 
         it 'should strip usecs from arguments when finding occurrences' do
           schedule = Schedule.new(Time.utc(2012, 4, 1, 10, 00))
           schedule.rrule Rule.weekly
           time = schedule.occurrences_between(Time.utc(2012,5,1,10,00,00,4), Time.utc(2012, 5, 15)).first
-          time.usec.should == 0
+          expect(time.usec).to eq(0)
         end
 
       end

--- a/spec/examples/rfc_spec.rb
+++ b/spec/examples/rfc_spec.rb
@@ -14,7 +14,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     dates = schedule.all_occurrences
     expectation = (Date.civil(1997, 9, 2)..Date.civil(1997, 12, 24)).to_a
     expectation = expectation.map { |d| Time.utc(d.year, d.month, d.day) }
-    dates.should == expectation
+    expect(dates).to eq(expectation)
   end
 
   it 'should ~ every other day' do
@@ -23,8 +23,8 @@ describe IceCube::Schedule, 'occurs_on?' do
     dates = schedule.occurrences(Time.utc(1997, 12, 31))
     offset = 0
     (Date.new(1997, 9, 2)..Date.new(1997, 12, 24)).each do |date|
-      dates.should include(Time.utc(date.year, date.month, date.day)) if offset % 2 == 0
-      dates.should_not include(Time.utc(date.year, date.month, date.day)) if offset % 2 != 0
+      expect(dates).to include(Time.utc(date.year, date.month, date.day)) if offset % 2 == 0
+      expect(dates).not_to include(Time.utc(date.year, date.month, date.day)) if offset % 2 != 0
       offset += 1
     end
   end
@@ -33,7 +33,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule = IceCube::Schedule.new(Time.utc(1997, 9, 2))
     schedule.add_recurrence_rule IceCube::Rule.daily(10).count(5)
     dates = schedule.occurrences(Time.utc(1998, 1, 1))
-    dates.should == [Time.utc(1997, 9, 2), Time.utc(1997, 9, 12), Time.utc(1997, 9, 22), Time.utc(1997, 10, 2), Time.utc(1997, 10, 12)]
+    expect(dates).to eq([Time.utc(1997, 9, 2), Time.utc(1997, 9, 12), Time.utc(1997, 9, 22), Time.utc(1997, 10, 2), Time.utc(1997, 10, 12)])
   end
 
   it 'should ~ everyday in january, for 3 years (a)' do
@@ -41,8 +41,8 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule.add_recurrence_rule IceCube::Rule.yearly.until(Time.utc(2000, 1, 31)).month_of_year(:january).day(:sunday, :monday, :tuesday, :wednesday, :thursday, :friday, :saturday)
     dates = schedule.occurrences(Time.utc(2000, 1, 31))
     dates.each do |date|
-      date.month.should == 1
-      [1998, 1999, 2000].should include(date.year)
+      expect(date.month).to eq(1)
+      expect([1998, 1999, 2000]).to include(date.year)
     end
   end
 
@@ -51,8 +51,8 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule.add_recurrence_rule IceCube::Rule.daily.month_of_year(:january).until(Time.utc(2000, 1, 31))
     dates = schedule.occurrences(Time.utc(2000, 1, 31))
     dates.each do |date|
-      date.month.should == 1
-      [1998, 1999, 2000].should include(date.year)
+      expect(date.month).to eq(1)
+      expect([1998, 1999, 2000]).to include(date.year)
     end
   end
 
@@ -60,7 +60,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule = IceCube::Schedule.new(Time.utc(1997, 9, 2))
     schedule.add_recurrence_rule IceCube::Rule.weekly.count(10)
     dates = schedule.occurrences(Time.utc(2000, 1, 1))
-    dates.should == [Time.utc(1997, 9, 2), Time.utc(1997, 9, 9), Time.utc(1997, 9, 16), Time.utc(1997, 9, 23), Time.utc(1997, 9, 30), Time.utc(1997, 10, 7), Time.utc(1997, 10, 14), Time.utc(1997, 10, 21), Time.utc(1997, 10, 28), Time.utc(1997, 11, 4)]
+    expect(dates).to eq([Time.utc(1997, 9, 2), Time.utc(1997, 9, 9), Time.utc(1997, 9, 16), Time.utc(1997, 9, 23), Time.utc(1997, 9, 30), Time.utc(1997, 10, 7), Time.utc(1997, 10, 14), Time.utc(1997, 10, 21), Time.utc(1997, 10, 28), Time.utc(1997, 11, 4)])
   end
 
   it 'should ~ weekly until december 24, 1997' do
@@ -79,7 +79,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     #check assumption
     previous_date = dates.shift
     dates.each do |date|
-      date.yday.should == previous_date.yday + 14
+      expect(date.yday).to eq(previous_date.yday + 14)
       previous_date = date
     end
   end
@@ -93,7 +93,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     expectation = []
     expectation << [2, 4, 9, 11, 16, 18, 23, 25, 30].map { |d| Time.utc(1997, 9, d) }
     expectation << [2].map { |d| Time.utc(1997, 10, d) }
-    dates.should == expectation.flatten
+    expect(dates).to eq(expectation.flatten)
   end
 
   it 'should ~ weekly on tuesday and thursday for 5 weeks (b)' do
@@ -104,7 +104,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     expectation = []
     expectation << [2, 4, 9, 11, 16, 18, 23, 25, 30].map { |d| Time.utc(1997, 9, d) }
     expectation << [2].map { |d| Time.utc(1997, 10, d) }
-    dates.should == expectation.flatten
+    expect(dates).to eq(expectation.flatten)
   end
 
   #
@@ -118,7 +118,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     expectation << [1, 3, 13, 15, 17, 27, 29, 31].map { |d| Time.utc(1997, 10, d) }
     expectation << [10, 12, 14, 24, 26, 28].map { |d| Time.utc(1997, 11, d) }
     expectation << [8, 10, 12, 22, 24].map { |d| Time.utc(1997, 12, d) }
-    dates.should == expectation.flatten
+    expect(dates).to eq(expectation.flatten)
   end
 
   it 'should ~ every other week on tuesday and thursday for 8 occurrences' do
@@ -129,7 +129,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     expectation = []
     expectation << [2, 4, 16, 18, 30].map { |d| Time.utc(1997, 9, d) }
     expectation << [2, 14, 16].map { |d| Time.utc(1997, 10, d) }
-    dates.should == expectation.flatten
+    expect(dates).to eq(expectation.flatten)
   end
 
   it 'should ~ monthly on the 1st friday for ten occurrences' do
@@ -138,7 +138,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule.add_recurrence_rule IceCube::Rule.monthly.day_of_week(:friday => [1]).count(10)
     dates = schedule.occurrences(Time.utc(1998, 7, 1))
     expectation = [Time.utc(1997, 9, 5), Time.utc(1997, 10, 3), Time.utc(1997, 11, 7), Time.utc(1997, 12, 5), Time.utc(1998, 1, 2), Time.utc(1998, 2, 6), Time.utc(1998, 3, 6), Time.utc(1998, 4, 3), Time.utc(1998, 5, 1), Time.utc(1998, 6, 5)]
-    dates.should == expectation
+    expect(dates).to eq(expectation)
   end
 
   it 'should ~ monthly on the first friday until december 24, 1997' do
@@ -147,7 +147,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule.add_recurrence_rule IceCube::Rule.monthly.until(Time.utc(1997, 12, 24)).day_of_week(:friday => [1])
     dates = schedule.occurrences(Time.utc(1998, 12, 24))
     expectation = [Time.utc(1997, 9, 5), Time.utc(1997, 10, 3), Time.utc(1997, 11, 7), Time.utc(1997, 12, 5)]
-    dates.should == expectation
+    expect(dates).to eq(expectation)
   end
 
   it 'should ~ every other month on the 1st and last sunday of the month for 10 occurrences' do
@@ -156,7 +156,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule.add_recurrence_rule IceCube::Rule.monthly(2).day_of_week(:sunday => [1, -1]).count(10)
     dates = schedule.occurrences(Time.utc(1998, 12, 1))
     expectation = [Time.utc(1997, 9, 7), Time.utc(1997, 9, 28), Time.utc(1997, 11, 2), Time.utc(1997, 11, 30), Time.utc(1998, 1, 4), Time.utc(1998, 1, 25), Time.utc(1998, 3, 1), Time.utc(1998, 3, 29), Time.utc(1998, 5, 3), Time.utc(1998, 5, 31)]
-    dates.should == expectation
+    expect(dates).to eq(expectation)
   end
 
   it 'should ~ monthly on the second to last monday of the month for 6 months' do
@@ -165,7 +165,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule.add_recurrence_rule IceCube::Rule.monthly.day_of_week(:monday => [-2]).count(6)
     dates = schedule.occurrences(Time.utc(1998, 3, 1))
     expectation = [Time.utc(1997, 9, 22), Time.utc(1997, 10, 20), Time.utc(1997, 11, 17), Time.utc(1997, 12, 22), Time.utc(1998, 1, 19), Time.utc(1998, 2, 16)]
-    dates.should == expectation
+    expect(dates).to eq(expectation)
   end
 
   it 'should ~ monthly on the third to last day of the month, 6 times' do
@@ -174,7 +174,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule.add_recurrence_rule IceCube::Rule.monthly.day_of_month(-3).count(6)
     dates = schedule.occurrences(Time.utc(1998, 2, 26))
     expectation = [Time.utc(1997, 9, 28), Time.utc(1997, 10, 29), Time.utc(1997, 11, 28), Time.utc(1997, 12, 29), Time.utc(1998, 1, 29), Time.utc(1998, 2, 26)]
-    dates.should == expectation
+    expect(dates).to eq(expectation)
   end
 
   it 'should ~ monthly on the 2nd and 15th of the month for 10 occurrences' do
@@ -183,7 +183,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule.add_recurrence_rule IceCube::Rule.monthly.day_of_month(2, 15).count(10)
     dates = schedule.occurrences(Time.utc(1998, 1, 16))
     expectation = [Time.utc(1997, 9, 2), Time.utc(1997, 9, 15), Time.utc(1997, 10, 2), Time.utc(1997, 10, 15), Time.utc(1997, 11, 2), Time.utc(1997, 11, 15), Time.utc(1997, 12, 2), Time.utc(1997, 12, 15), Time.utc(1998, 1, 2), Time.utc(1998, 1, 15)]
-    dates.should == expectation
+    expect(dates).to eq(expectation)
   end
 
   it 'should ~ monthly on the 1st and last days of the month for 10 occurrences' do
@@ -192,7 +192,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule.add_recurrence_rule IceCube::Rule.monthly.day_of_month(1, -1).count(10)
     dates = schedule.occurrences(Time.utc(1998, 2, 2))
     expectation = [Time.utc(1997, 9, 30), Time.utc(1997, 10, 1), Time.utc(1997, 10, 31), Time.utc(1997, 11, 1), Time.utc(1997, 11, 30), Time.utc(1997, 12, 1), Time.utc(1997, 12, 31), Time.utc(1998, 1, 1), Time.utc(1998, 1, 31), Time.utc(1998, 2, 1)]
-    dates.should == expectation
+    expect(dates).to eq(expectation)
   end
 
   it 'should ~ every 18 months on the 10th through the 15th of the month for 10 occurrences' do
@@ -202,7 +202,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     expectation = []
     expectation << [10, 11, 12, 13, 14, 15].map { |d| Time.utc(1997, 9, d) }
     expectation << [10, 11, 12, 13].map { |d| Time.utc(1999, 3, d) }
-    dates.should == expectation.flatten
+    expect(dates).to eq(expectation.flatten)
   end
 
   it 'should ~ every tuesday, every other month' do
@@ -214,7 +214,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     expectation << [4, 11, 18, 25].map { |d| Time.utc(1997, 11, d) }
     expectation << [6, 13, 20, 27].map { |d| Time.utc(1998, 1, d) }
     expectation << [3, 10, 17, 24, 31].map { |d| Time.utc(1998, 3, d) }
-    dates.should == expectation.flatten
+    expect(dates).to eq(expectation.flatten)
   end
 
   it 'should ~ yearly in june and july for 10 occurrences' do
@@ -226,7 +226,7 @@ describe IceCube::Schedule, 'occurs_on?' do
       expectation << Time.utc(year, 6, 10)
       expectation << Time.utc(year, 7, 10)
     end
-    dates.should == expectation.flatten
+    expect(dates).to eq(expectation.flatten)
   end
 
   it 'should ~ every other year on january, feburary, and march for 10 occurrences' do
@@ -234,7 +234,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule.add_recurrence_rule IceCube::Rule.yearly(2).month_of_year(:january, :february, :march).count(10)
     dates = schedule.occurrences(Time.utc(2003, 4, 1))
     expectation = [Time.utc(1997, 3, 10), Time.utc(1999, 1, 10), Time.utc(1999, 2, 10), Time.utc(1999, 3, 10), Time.utc(2001, 1, 10), Time.utc(2001, 2, 10), Time.utc(2001, 3, 10), Time.utc(2003, 1, 10), Time.utc(2003, 2, 10), Time.utc(2003, 3, 10)]
-    dates.should == expectation
+    expect(dates).to eq(expectation)
   end
 
   it 'should ~ every third year on the 1st, 100th and 200th day for 10 occurrences' do
@@ -242,7 +242,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule.add_recurrence_rule IceCube::Rule.yearly(3).day_of_year(1, 100, 200).count(10)
     dates = schedule.occurrences(Time.utc(2006, 1, 2))
     expectation = [Time.utc(1997, 1, 1), Time.utc(1997, 4, 10), Time.utc(1997, 7, 19), Time.utc(2000, 1, 1), Time.utc(2000, 4, 9), Time.utc(2000, 7, 18), Time.utc(2003, 1, 1), Time.utc(2003, 4, 10), Time.utc(2003, 7, 19), Time.utc(2006, 1, 1)]
-    dates.should == expectation
+    expect(dates).to eq(expectation)
   end
 
   it 'should ~ every thursday in march, forever' do
@@ -253,7 +253,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     expectation << [13, 20, 27].map { |d| Time.utc(1997, 3, d) }
     expectation << [5, 12, 19, 26].map { |d| Time.utc(1998, 3, d) }
     expectation << [4, 11, 18, 25].map { |d| Time.utc(1999, 3, d) }
-    dates.should == expectation.flatten
+    expect(dates).to eq(expectation.flatten)
   end
 
   it 'should ~ every thursday, but only during june, july, and august' do
@@ -267,7 +267,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     expectation << [4, 11, 18, 25].map { |d| Time.utc(1998, 6, d) }
     expectation << [2, 9, 16, 23, 30].map { |d| Time.utc(1998, 7, d) }
     expectation << [6, 13, 20, 27].map { |d| Time.utc(1998, 8, d) }
-    dates.should == expectation.flatten
+    expect(dates).to eq(expectation.flatten)
   end
 
   it 'should ~ every friday the 13th' do
@@ -275,7 +275,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule.add_recurrence_rule IceCube::Rule.monthly.day(:friday).day_of_month(13)
     dates = schedule.occurrences(Time.utc(2000, 10, 13))
     expectation = [Time.utc(1998, 2, 13), Time.utc(1998, 3, 13), Time.utc(1998, 11, 13), Time.utc(1999, 8, 13), Time.utc(2000, 10, 13)]
-    dates.should == expectation
+    expect(dates).to eq(expectation)
   end
 
   it 'should ~ the first saturday that follows the first sunday of the month' do
@@ -283,7 +283,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule.add_recurrence_rule IceCube::Rule.monthly.day(:saturday).day_of_month(7, 8, 9, 10, 11, 12, 13)
     dates = schedule.occurrences(Time.utc(1997, 12, 13))
     expectation = [Time.utc(1997, 9, 13), Time.utc(1997, 10, 11), Time.utc(1997, 11, 8), Time.utc(1997, 12, 13)]
-    dates.should == expectation
+    expect(dates).to eq(expectation)
   end
 
   it 'should ~ every 4 years, the first tuesday after a monday in november (u.s. presidential election day)' do
@@ -291,7 +291,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule.add_recurrence_rule IceCube::Rule.yearly(4).month_of_year(:november).day(:tuesday).day_of_month(2, 3, 4, 5, 6, 7, 8)
     dates = schedule.occurrences(Time.utc(2004, 11, 2))
     expectation = [Time.utc(1996, 11, 5), Time.utc(2000, 11, 7), Time.utc(2004, 11, 2)]
-    dates.should == expectation
+    expect(dates).to eq(expectation)
   end
 
   it 'should ~ every 3 hours from 9am to 5pm on a specific day' do
@@ -299,7 +299,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.hourly(3).until(Time.utc(1997, 9, 2, 17, 0, 0))
     dates = schedule.all_occurrences
-    dates.should == [Time.utc(1997, 9, 2, 9, 0, 0), Time.utc(1997, 9, 2, 12, 0, 0), Time.utc(1997, 9, 2, 15, 0, 0)]
+    expect(dates).to eq([Time.utc(1997, 9, 2, 9, 0, 0), Time.utc(1997, 9, 2, 12, 0, 0), Time.utc(1997, 9, 2, 15, 0, 0)])
   end
 
   it 'should ~ every 15 minutes for 6 occurrences' do
@@ -307,7 +307,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.minutely(15).count(6)
     dates = schedule.all_occurrences
-    dates.should == [Time.utc(1997, 9, 2, 9, 0, 0), Time.utc(1997, 9, 2, 9, 15, 0), Time.utc(1997, 9, 2, 9, 30, 0), Time.utc(1997, 9, 2, 9, 45, 0), Time.utc(1997, 9, 2, 10, 0, 0), Time.utc(1997, 9, 2, 10, 15, 0)]
+    expect(dates).to eq([Time.utc(1997, 9, 2, 9, 0, 0), Time.utc(1997, 9, 2, 9, 15, 0), Time.utc(1997, 9, 2, 9, 30, 0), Time.utc(1997, 9, 2, 9, 45, 0), Time.utc(1997, 9, 2, 10, 0, 0), Time.utc(1997, 9, 2, 10, 15, 0)])
   end
 
   it 'should ~ every hour and a half for 4 occurrences' do
@@ -315,7 +315,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.minutely(90).count(4)
     dates = schedule.all_occurrences
-    dates.should == [Time.utc(1997, 9, 2, 9, 0, 0), Time.utc(1997, 9, 2, 10, 30, 0), Time.utc(1997, 9, 2, 12, 0, 0), Time.utc(1997, 9, 2, 13, 30, 0)]
+    expect(dates).to eq([Time.utc(1997, 9, 2, 9, 0, 0), Time.utc(1997, 9, 2, 10, 30, 0), Time.utc(1997, 9, 2, 12, 0, 0), Time.utc(1997, 9, 2, 13, 30, 0)])
   end
 
   it 'should ~ every 20 minutes from 9am to 4:40pm every day (a)' do
@@ -325,7 +325,7 @@ describe IceCube::Schedule, 'occurs_on?' do
     schedule.add_recurrence_rule IceCube::Rule.daily.hour_of_day(9, 10, 11, 12, 13, 14, 15, 16).minute_of_hour(0, 20, 40).until(end_date)
     dates = schedule.all_occurrences
     expecation = [Time.utc(1997, 9, 2, 9), Time.utc(1997, 9, 2, 9, 20), Time.utc(1997, 9, 2, 9, 40), Time.utc(1997, 9, 2, 10, 0), Time.utc(1997, 9, 2, 10, 20)]
-    dates.should == expecation
+    expect(dates).to eq(expecation)
   end
 
 end
@@ -341,8 +341,8 @@ def test_expectations(schedule, dates_array)
   end
   # test equality
   expectation.sort!
-  schedule.occurrences(expectation.last).should == expectation
+  expect(schedule.occurrences(expectation.last)).to eq(expectation)
   expectation.each do |date|
-    schedule.should be_occurs_at(date)
+    expect(schedule).to be_occurs_at(date)
   end
 end

--- a/spec/examples/schedule_spec.rb
+++ b/spec/examples/schedule_spec.rb
@@ -9,28 +9,28 @@ describe IceCube::Schedule do
     schedule = IceCube::Schedule.new do |s|
       s.start_time = t1
     end
-    schedule.start_time.should == t1
+    expect(schedule.start_time).to eq(t1)
   end
 
   it 'initializes with a start_time' do
     t1 = Time.local(2013, 2, 14, 0, 32, 0)
     schedule = IceCube::Schedule.new(t1)
-    schedule.start_time.should be_a Time
-    schedule.start_time.should == t1
+    expect(schedule.start_time).to be_a Time
+    expect(schedule.start_time).to eq(t1)
   end
 
   it 'converts initialized DateTime to Time' do
     dt = DateTime.new(2013, 2, 14, 0, 32, 0)
     schedule = IceCube::Schedule.new(dt)
-    schedule.start_time.should be_a Time
-    schedule.start_time.should == Time.local(dt.year, dt.month, dt.day, dt.hour, dt.min, dt.sec)
+    expect(schedule.start_time).to be_a Time
+    expect(schedule.start_time).to eq(Time.local(dt.year, dt.month, dt.day, dt.hour, dt.min, dt.sec))
   end
 
   describe :next_occurrence do
 
     it 'should not raise an exception when calling next occurrence with no remaining occurrences' do
       schedule = IceCube::Schedule.new Time.now
-      lambda { schedule.next_occurrence }.should_not raise_error
+      expect { schedule.next_occurrence }.not_to raise_error
     end
 
   end
@@ -40,16 +40,16 @@ describe IceCube::Schedule do
     it 'should be based on end_time' do
       start = Time.now
       schedule = IceCube::Schedule.new(start)
-      schedule.duration.should == 0
+      expect(schedule.duration).to eq(0)
       schedule.end_time = start + 3600
-      schedule.duration.should == 3600
+      expect(schedule.duration).to eq(3600)
     end
 
     it 'should give precedence to :end_time option' do
       start = Time.now
       conflicting_options = {:end_time => start + 600, :duration => 1200}
       schedule = IceCube::Schedule.new(start, conflicting_options)
-      schedule.duration.should == 600
+      expect(schedule.duration).to eq(600)
     end
 
   end
@@ -57,19 +57,19 @@ describe IceCube::Schedule do
   describe :recurrence_times do
 
     it 'should start empty' do
-      IceCube::Schedule.new.recurrence_times.should be_empty
+      expect(IceCube::Schedule.new.recurrence_times).to be_empty
     end
 
     it 'should include added times' do
       schedule = IceCube::Schedule.new(t0 = Time.now)
       schedule.add_recurrence_time(t1 = t0 + 3600)
-      schedule.recurrence_times.should == [t1]
+      expect(schedule.recurrence_times).to eq([t1])
     end
 
     it 'can include start time' do
       schedule = IceCube::Schedule.new(t0 = Time.now)
       schedule.add_recurrence_time(t0)
-      schedule.recurrence_times.should == [t0]
+      expect(schedule.recurrence_times).to eq([t0])
     end
 
   end
@@ -82,9 +82,9 @@ describe IceCube::Schedule do
         schedule.rrule IceCube::Rule.daily
         schedule
       end
-      lambda do
+      expect do
         schedules.first.conflicts_with?(schedules.last)
-      end.should raise_error ArgumentError
+      end.to raise_error ArgumentError
     end
 
     it 'should not raise error if both are non-terminating closing time present' do
@@ -92,9 +92,9 @@ describe IceCube::Schedule do
       schedule1.rrule IceCube::Rule.weekly
       schedule2 = IceCube::Schedule.new Time.now
       schedule2.rrule IceCube::Rule.weekly
-      lambda do
+      expect do
         schedule1.conflicts_with?(schedule2, Time.now + IceCube::ONE_DAY)
-      end.should_not raise_error
+      end.not_to raise_error
     end
 
     it 'should not raise an error if one is non-terminating' do
@@ -102,9 +102,9 @@ describe IceCube::Schedule do
       schedule1.rrule IceCube::Rule.weekly
       schedule2 = IceCube::Schedule.new Time.now
       schedule2.rrule IceCube::Rule.weekly.until(Time.now)
-      lambda do
+      expect do
         schedule1.conflicts_with?(schedule2)
-      end.should_not raise_error
+      end.not_to raise_error
     end
 
     it 'should not raise an error if the other is non-terminating' do
@@ -112,9 +112,9 @@ describe IceCube::Schedule do
       schedule1.rrule IceCube::Rule.weekly.until(Time.now)
       schedule2 = IceCube::Schedule.new Time.now
       schedule2.rrule IceCube::Rule.weekly
-      lambda do
+      expect do
         schedule1.conflicts_with?(schedule2)
-      end.should_not raise_error
+      end.not_to raise_error
     end
 
     it 'should return true if conflict is present' do
@@ -124,7 +124,7 @@ describe IceCube::Schedule do
       schedule2 = IceCube::Schedule.new(start_time)
       schedule2.rrule IceCube::Rule.daily
       conflict = schedule1.conflicts_with?(schedule2, start_time + IceCube::ONE_DAY)
-      conflict.should be_true
+      expect(conflict).to be_true
     end
 
     it 'should return false if conflict is not present' do
@@ -134,7 +134,7 @@ describe IceCube::Schedule do
       schedule2 = IceCube::Schedule.new(start_time)
       schedule2.rrule IceCube::Rule.weekly.day(:monday)
       conflict = schedule1.conflicts_with?(schedule2, start_time + IceCube::ONE_DAY)
-      conflict.should be_false
+      expect(conflict).to be_false
     end
 
     it 'should return true if conflict is present based on duration' do
@@ -144,7 +144,7 @@ describe IceCube::Schedule do
       schedule2 = IceCube::Schedule.new(start_time)
       schedule2.rrule IceCube::Rule.weekly.day(:tuesday)
       conflict = schedule1.conflicts_with?(schedule2, start_time + IceCube::ONE_WEEK)
-      conflict.should be_true
+      expect(conflict).to be_true
     end
 
     it 'should return true if conflict is present based on duration - other way' do
@@ -154,7 +154,7 @@ describe IceCube::Schedule do
       schedule2 = IceCube::Schedule.new(start_time, :duration => IceCube::ONE_DAY + 1)
       schedule2.rrule IceCube::Rule.weekly.day(:monday)
       conflict = schedule1.conflicts_with?(schedule2, start_time + IceCube::ONE_WEEK)
-      conflict.should be_true
+      expect(conflict).to be_true
     end
 
     it 'should return false if conflict is past closing_time' do
@@ -163,10 +163,10 @@ describe IceCube::Schedule do
       schedule1.rrule IceCube::Rule.weekly.day(:friday)
       schedule2 = IceCube::Schedule.new(start_time)
       schedule2.rrule IceCube::Rule.weekly.day(:friday)
-      schedule2.conflicts_with?(schedule1, start_time + IceCube::ONE_WEEK).
-        should be_true
-      schedule2.conflicts_with?(schedule1, start_time + IceCube::ONE_DAY).
-        should be_false
+      expect(schedule2.conflicts_with?(schedule1, start_time + IceCube::ONE_WEEK)).
+        to be_true
+      expect(schedule2.conflicts_with?(schedule1, start_time + IceCube::ONE_DAY)).
+        to be_false
     end
 
     it 'should return false if conflict is not present based on duration' do
@@ -176,7 +176,7 @@ describe IceCube::Schedule do
       schedule2 = IceCube::Schedule.new(start_time, :duration => IceCube::ONE_HOUR)
       schedule2.rrule IceCube::Rule.weekly.day(:tuesday)
       conflict = schedule1.conflicts_with?(schedule2, start_time + IceCube::ONE_WEEK)
-      conflict.should be_false
+      expect(conflict).to be_false
     end
 
     it 'should return false if conflict is not present on same day based on duration' do
@@ -186,7 +186,7 @@ describe IceCube::Schedule do
       schedule2 = IceCube::Schedule.new(start_time + 3600, :duration => IceCube::ONE_HOUR)
       schedule2.rrule IceCube::Rule.daily
       conflict = schedule1.conflicts_with?(schedule2, start_time + IceCube::ONE_WEEK)
-      conflict.should be_false
+      expect(conflict).to be_false
     end
 
     it 'should return true if conflict is present on same day based on duration' do
@@ -196,7 +196,7 @@ describe IceCube::Schedule do
       schedule2 = IceCube::Schedule.new(start_time + 600, :duration => IceCube::ONE_HOUR)
       schedule2.rrule IceCube::Rule.daily
       conflict = schedule1.conflicts_with?(schedule2, start_time + IceCube::ONE_WEEK)
-      conflict.should be_true
+      expect(conflict).to be_true
     end
 
     it 'should return true if conflict is present and no recurrence' do
@@ -206,9 +206,9 @@ describe IceCube::Schedule do
       schedule2 = IceCube::Schedule.new(start_time + 600, :duration => IceCube::ONE_HOUR)
       schedule2.add_recurrence_time(start_time + 600)
       conflict = schedule1.conflicts_with?(schedule2)
-      conflict.should be_true
+      expect(conflict).to be_true
       conflict = schedule2.conflicts_with?(schedule1)
-      conflict.should be_true
+      expect(conflict).to be_true
     end
 
     it 'should return false if conflict is not present and no recurrence' do
@@ -218,9 +218,9 @@ describe IceCube::Schedule do
       schedule2 = IceCube::Schedule.new(start_time + IceCube::ONE_HOUR, :duration => IceCube::ONE_HOUR)
       schedule2.add_recurrence_time(start_time + IceCube::ONE_HOUR)
       conflict = schedule1.conflicts_with?(schedule2)
-      conflict.should be_false
+      expect(conflict).to be_false
       conflict = schedule2.conflicts_with?(schedule1)
-      conflict.should be_false
+      expect(conflict).to be_false
     end
 
     it 'should return false if conflict is not present and single recurrence' do
@@ -230,9 +230,9 @@ describe IceCube::Schedule do
       schedule2 = IceCube::Schedule.new(start_time + IceCube::ONE_HOUR, :duration => IceCube::ONE_HOUR)
       schedule2.rrule IceCube::Rule.daily
       conflict = schedule1.conflicts_with?(schedule2)
-      conflict.should be_false
+      expect(conflict).to be_false
       conflict = schedule2.conflicts_with?(schedule1)
-      conflict.should be_false
+      expect(conflict).to be_false
     end
 
    it 'should return true if conflict is present and single recurrence' do
@@ -242,9 +242,9 @@ describe IceCube::Schedule do
       schedule2 = IceCube::Schedule.new(start_time + 600, :duration => IceCube::ONE_HOUR)
       schedule2.rrule IceCube::Rule.daily
       conflict = schedule1.conflicts_with?(schedule2)
-      conflict.should be_true
+      expect(conflict).to be_true
       conflict = schedule2.conflicts_with?(schedule1)
-      conflict.should be_true
+      expect(conflict).to be_true
     end
 
     it 'should return false if conflict is not present and single recurrence and time originally specified as Time' do
@@ -254,9 +254,9 @@ describe IceCube::Schedule do
       schedule2 = IceCube::Schedule.new(start_time + IceCube::ONE_HOUR, :duration => IceCube::ONE_HOUR)
       schedule2.add_recurrence_time(start_time + IceCube::ONE_HOUR)
       conflict = schedule1.conflicts_with?(schedule2)
-      conflict.should be_false
+      expect(conflict).to be_false
       conflict = schedule2.conflicts_with?(schedule1)
-      conflict.should be_false
+      expect(conflict).to be_false
     end
 
   end
@@ -273,12 +273,12 @@ describe IceCube::Schedule do
         i += 1
         break if i > 9
       end
-      answers.should == schedule.first(10)
+      expect(answers).to eq(schedule.first(10))
     end
 
     it 'should return self' do
       schedule = IceCube::Schedule.new
-      schedule.each_occurrence { |s| }.should == schedule
+      expect(schedule.each_occurrence { |s| }).to eq(schedule)
     end
 
     it 'should stop itself when hitting the end of a schedule' do
@@ -287,7 +287,7 @@ describe IceCube::Schedule do
       schedule.add_recurrence_time t1
       answers = []
       schedule.each_occurrence { |t| answers << t }
-      answers.should == [t0, t1]
+      expect(answers).to eq([t0, t1])
     end
 
   end
@@ -313,39 +313,39 @@ describe IceCube::Schedule do
     it 'has end times for each occurrence' do
       schedule = IceCube::Schedule.new(Time.now, :duration => IceCube::ONE_HOUR)
       schedule.add_recurrence_rule IceCube::Rule.daily.until(Time.now + 3 * IceCube::ONE_DAY)
-      schedule.all_occurrences.all? { |o| o.end_time.should == o + IceCube::ONE_HOUR }
+      schedule.all_occurrences.all? { |o| expect(o.end_time).to eq(o + IceCube::ONE_HOUR) }
     end
 
     it 'should include its start time when empty' do
       schedule = IceCube::Schedule.new(t0 = Time.now)
-      schedule.all_occurrences.should == [t0]
+      expect(schedule.all_occurrences).to eq([t0])
     end
 
    it 'should have one occurrence with one recurrence time at start_time' do
       schedule = IceCube::Schedule.new(t0 = Time.local(2012, 12, 12, 12, 12, 12))
       schedule.add_recurrence_time t0
-      schedule.all_occurrences.should == [t0]
+      expect(schedule.all_occurrences).to eq([t0])
     end
 
     it 'should have two occurrences with a recurrence time after start_time' do
       schedule = IceCube::Schedule.new(t0 = Time.local(2012, 12, 12, 12, 12, 12))
       schedule.add_recurrence_time t1 = Time.local(2013,  1, 13,  1, 13,  1)
-      schedule.all_occurrences.should == [t0, t1]
+      expect(schedule.all_occurrences).to eq([t0, t1])
     end
 
     it 'should return an error if there is nothing to stop it' do
       schedule = IceCube::Schedule.new
       schedule.rrule IceCube::Rule.daily
-      lambda do
+      expect do
         schedule.all_occurrences
-      end.should raise_error ArgumentError
+      end.to raise_error ArgumentError
     end
 
     it 'should consider count limits separately for multiple rules' do
       schedule = IceCube::Schedule.new
       schedule.rrule IceCube::Rule.minutely.count(3)
       schedule.rrule IceCube::Rule.daily.count(3)
-      schedule.all_occurrences.size.should == 5
+      expect(schedule.all_occurrences.size).to eq(5)
     end
 
   end
@@ -360,10 +360,10 @@ describe IceCube::Schedule do
       schedule.rrule IceCube::Rule.daily(1)
       schedule.extime start_time + IceCube::ONE_DAY
       occurrences = schedule.next_occurrences(2, start_time) # 3 occurrences in the next year
-      occurrences.should == [
+      expect(occurrences).to eq([
         start_time + IceCube::ONE_DAY * 2,
         start_time + IceCube::ONE_DAY * 3
-      ]
+      ])
     end
 
     it 'should be empty if nothing is found before closing time' do
@@ -372,7 +372,7 @@ describe IceCube::Schedule do
         s.add_recurrence_rule nonsense.until(next_year)
       end
       trap_infinite_loop_beyond(24)
-      schedule.next_occurrences(1).should be_empty
+      expect(schedule.next_occurrences(1)).to be_empty
     end
 
   end
@@ -385,7 +385,7 @@ describe IceCube::Schedule do
       schedule.rrule IceCube::Rule.daily(1)
       schedule.extime start_time + IceCube::ONE_DAY
       occurrence = schedule.next_occurrence(start_time) # 3 occurrences in the next year
-      occurrence.should == start_time + IceCube::ONE_DAY * 2
+      expect(occurrence).to eq(start_time + IceCube::ONE_DAY * 2)
     end
 
     it 'should respect time zone info for a local future time [#115]' do
@@ -427,7 +427,7 @@ describe IceCube::Schedule do
       schedule = IceCube::Schedule.new(t0)
       schedule.add_recurrence_rule IceCube::Rule.daily
       previous = schedule.previous_occurrence(t0 + 2 * ONE_DAY)
-      previous.should == t0 + ONE_DAY
+      expect(previous).to eq(t0 + ONE_DAY)
     end
 
     it 'returns nil given the start time' do
@@ -435,7 +435,7 @@ describe IceCube::Schedule do
       schedule = IceCube::Schedule.new(t0)
       schedule.add_recurrence_rule IceCube::Rule.daily
       previous = schedule.previous_occurrence(t0)
-      previous.should be_nil
+      expect(previous).to be_nil
     end
 
   end
@@ -447,7 +447,7 @@ describe IceCube::Schedule do
       schedule = IceCube::Schedule.new(t0)
       schedule.add_recurrence_rule IceCube::Rule.daily
       previous = schedule.previous_occurrences(2, t0 + 3 * ONE_DAY)
-      previous.should == [t0 + ONE_DAY, t0 + 2 * ONE_DAY]
+      expect(previous).to eq([t0 + ONE_DAY, t0 + 2 * ONE_DAY])
     end
 
     it 'limits the returned occurrences to a given count' do
@@ -455,7 +455,7 @@ describe IceCube::Schedule do
       schedule = IceCube::Schedule.new(t0)
       schedule.add_recurrence_rule IceCube::Rule.daily
       previous = schedule.previous_occurrences(999, t0 + 2 * ONE_DAY)
-      previous.should == [t0, t0 + ONE_DAY]
+      expect(previous).to eq([t0, t0 + ONE_DAY])
     end
 
     it 'returns empty array given the start time' do
@@ -463,7 +463,7 @@ describe IceCube::Schedule do
       schedule = IceCube::Schedule.new(t0)
       schedule.add_recurrence_rule IceCube::Rule.daily
       previous = schedule.previous_occurrences(2, t0)
-      previous.should == []
+      expect(previous).to eq([])
     end
 
   end
@@ -475,7 +475,7 @@ describe IceCube::Schedule do
       t1 = Time.utc(2013, 5, 31, 12, 34)
       schedule = IceCube::Schedule.new(t0)
       schedule.add_recurrence_rule IceCube::Rule.daily.until(t1 + 1)
-      schedule.last.should == t1
+      expect(schedule.last).to eq(t1)
     end
 
     it 'returns an array of occurrences given a number' do
@@ -483,7 +483,7 @@ describe IceCube::Schedule do
       t1 = Time.utc(2013, 5, 31, 12, 34)
       schedule = IceCube::Schedule.new(t0)
       schedule.add_recurrence_rule IceCube::Rule.daily.until(t1 + 1)
-      schedule.last(2).should == [t1 - ONE_DAY, t1]
+      expect(schedule.last(2)).to eq([t1 - ONE_DAY, t1])
     end
 
     it 'raises an error for a non-terminating schedule' do
@@ -500,7 +500,7 @@ describe IceCube::Schedule do
       schedule = IceCube::Schedule.new(Time.now - 1000)
       schedule.rrule IceCube::Rule.daily
       schedule.start_time = (start_date = Time.now)
-      (Time.now - schedule.first.start_time).should be < 100
+      expect(Time.now - schedule.first.start_time).to be < 100
     end
 
   end
@@ -510,7 +510,7 @@ describe IceCube::Schedule do
     it 'should not include rules for single occurrences' do
       schedule = IceCube::Schedule.new Time.now
       schedule.add_recurrence_time Time.now
-      schedule.rrules.should be_empty
+      expect(schedule.rrules).to be_empty
     end
 
   end
@@ -522,7 +522,7 @@ describe IceCube::Schedule do
       schedule.rrule IceCube::Rule.daily
       schedule.rrule IceCube::Rule.daily(2)
       schedule.remove_recurrence_rule schedule.rrules.first
-      schedule.rrules.count.should == 1
+      expect(schedule.rrules.count).to eq(1)
     end
 
     it 'should be able to remove multiple rules based on the comparator' do
@@ -530,7 +530,7 @@ describe IceCube::Schedule do
       schedule.rrule IceCube::Rule.daily
       schedule.rrule IceCube::Rule.daily
       schedule.remove_recurrence_rule schedule.rrules.first
-      schedule.rrules.should be_empty
+      expect(schedule.rrules).to be_empty
     end
 
     it 'should return the rule that was removed' do
@@ -538,13 +538,13 @@ describe IceCube::Schedule do
       rule = IceCube::Rule.daily
       schedule.rrule rule
       rule2 = schedule.remove_recurrence_rule rule
-      [rule].should == rule2
+      expect([rule]).to eq(rule2)
     end
 
     it 'should return [] if nothing was removed' do
       schedule = IceCube::Schedule.new Time.now
       rule = IceCube::Rule.daily
-      schedule.remove_recurrence_rule(rule).should == []
+      expect(schedule.remove_recurrence_rule(rule)).to eq([])
     end
 
   end
@@ -556,7 +556,7 @@ describe IceCube::Schedule do
       schedule.exrule IceCube::Rule.daily
       schedule.exrule IceCube::Rule.daily(2)
       schedule.remove_exception_rule schedule.exrules.first
-      schedule.exrules.count.should == 1
+      expect(schedule.exrules.count).to eq(1)
     end
 
     it 'should be able to remove multiple rules based on the comparator' do
@@ -564,7 +564,7 @@ describe IceCube::Schedule do
       schedule.exrule IceCube::Rule.daily
       schedule.exrule IceCube::Rule.daily
       schedule.remove_exception_rule schedule.exrules.first
-      schedule.exrules.should be_empty
+      expect(schedule.exrules).to be_empty
     end
 
     it 'should return the rule that was removed' do
@@ -572,13 +572,13 @@ describe IceCube::Schedule do
       rule = IceCube::Rule.daily
       schedule.exrule rule
       rule2 = schedule.remove_exception_rule rule
-      [rule].should == rule2
+      expect([rule]).to eq(rule2)
     end
 
     it 'should return [] if nothing was removed' do
       schedule = IceCube::Schedule.new Time.now
       rule = IceCube::Rule.daily
-      schedule.remove_exception_rule(rule).should == []
+      expect(schedule.remove_exception_rule(rule)).to eq([])
     end
 
   end
@@ -590,19 +590,19 @@ describe IceCube::Schedule do
       schedule = IceCube::Schedule.new(time)
       schedule.add_recurrence_time time
       schedule.remove_recurrence_time time
-      schedule.recurrence_times.should be_empty
+      expect(schedule.recurrence_times).to be_empty
     end
 
     it 'should return the time that was removed' do
       schedule = IceCube::Schedule.new Time.now
       time = Time.now
       schedule.rtime time
-      schedule.remove_rtime(time).should == time
+      expect(schedule.remove_rtime(time)).to eq(time)
     end
 
     it 'should return nil if the date was not in the schedule' do
       schedule = IceCube::Schedule.new Time.now
-      schedule.remove_recurrence_time(Time.now).should be_nil
+      expect(schedule.remove_recurrence_time(Time.now)).to be_nil
     end
 
   end
@@ -614,19 +614,19 @@ describe IceCube::Schedule do
       schedule = IceCube::Schedule.new(time)
       schedule.extime time
       schedule.remove_exception_time time
-      schedule.exception_times.should be_empty
+      expect(schedule.exception_times).to be_empty
     end
 
     it 'should return the date that was removed' do
       schedule = IceCube::Schedule.new Time.now
       time = Time.now
       schedule.extime time
-      schedule.remove_extime(time).should == time
+      expect(schedule.remove_extime(time)).to eq(time)
     end
 
     it 'should return nil if the date was not in the schedule' do
       schedule = IceCube::Schedule.new Time.now
-      schedule.remove_exception_time(Time.now).should be_nil
+      expect(schedule.remove_exception_time(Time.now)).to be_nil
     end
 
   end
@@ -639,38 +639,38 @@ describe IceCube::Schedule do
       WORLD_TIME_ZONES.each do |zone|
         context "in #{zone}", :system_time_zone => zone do
           specify 'should determine if it occurs on a given Date' do
-            schedule.occurs_on?(Date.new(2010, 7, 1)).should be_false
-            schedule.occurs_on?(Date.new(2010, 7, 2)).should be_true
-            schedule.occurs_on?(Date.new(2010, 7, 3)).should be_false
+            expect(schedule.occurs_on?(Date.new(2010, 7, 1))).to be_false
+            expect(schedule.occurs_on?(Date.new(2010, 7, 2))).to be_true
+            expect(schedule.occurs_on?(Date.new(2010, 7, 3))).to be_false
           end
 
           specify 'should determine if it occurs on the day of a given UTC Time' do
-            schedule.occurs_on?(Time.utc(2010, 7, 1, 23, 59, 59)).should be_false
-            schedule.occurs_on?(Time.utc(2010, 7, 2,  0,  0,  1)).should be_true
-            schedule.occurs_on?(Time.utc(2010, 7, 2, 23, 59, 59)).should be_true
-            schedule.occurs_on?(Time.utc(2010, 7, 3,  0,  0,  1)).should be_false
+            expect(schedule.occurs_on?(Time.utc(2010, 7, 1, 23, 59, 59))).to be_false
+            expect(schedule.occurs_on?(Time.utc(2010, 7, 2,  0,  0,  1))).to be_true
+            expect(schedule.occurs_on?(Time.utc(2010, 7, 2, 23, 59, 59))).to be_true
+            expect(schedule.occurs_on?(Time.utc(2010, 7, 3,  0,  0,  1))).to be_false
           end
 
           specify 'should determine if it occurs on the day of a given local Time' do
-            schedule.occurs_on?(Time.local(2010, 7, 1, 23, 59, 59)).should be_false
-            schedule.occurs_on?(Time.local(2010, 7, 2,  0,  0,  1)).should be_true
-            schedule.occurs_on?(Time.local(2010, 7, 2, 23, 59, 59)).should be_true
-            schedule.occurs_on?(Time.local(2010, 7, 3,  0,  0,  1)).should be_false
+            expect(schedule.occurs_on?(Time.local(2010, 7, 1, 23, 59, 59))).to be_false
+            expect(schedule.occurs_on?(Time.local(2010, 7, 2,  0,  0,  1))).to be_true
+            expect(schedule.occurs_on?(Time.local(2010, 7, 2, 23, 59, 59))).to be_true
+            expect(schedule.occurs_on?(Time.local(2010, 7, 3,  0,  0,  1))).to be_false
           end
 
           specify 'should determine if it occurs on the day of a given non-local Time' do
-            schedule.occurs_on?(Time.new(2010, 7, 1, 23, 59, 59, "+11:15")).should be_false
-            schedule.occurs_on?(Time.new(2010, 7, 2,  0,  0,  1, "+11:15")).should be_true
-            schedule.occurs_on?(Time.new(2010, 7, 2, 23, 59, 59, "+11:15")).should be_true
-            schedule.occurs_on?(Time.new(2010, 7, 3,  0,  0,  1, "+11:15")).should be_false
+            expect(schedule.occurs_on?(Time.new(2010, 7, 1, 23, 59, 59, "+11:15"))).to be_false
+            expect(schedule.occurs_on?(Time.new(2010, 7, 2,  0,  0,  1, "+11:15"))).to be_true
+            expect(schedule.occurs_on?(Time.new(2010, 7, 2, 23, 59, 59, "+11:15"))).to be_true
+            expect(schedule.occurs_on?(Time.new(2010, 7, 3,  0,  0,  1, "+11:15"))).to be_false
           end
 
           specify 'should determine if it occurs on the day of a given ActiveSupport::Time', :if_active_support_time => true do
             Time.zone = "Pacific/Honolulu"
-            schedule.occurs_on?(Time.zone.parse('2010-07-01 23:59:59')).should be_false
-            schedule.occurs_on?(Time.zone.parse('2010-07-02 00:00:01')).should be_true
-            schedule.occurs_on?(Time.zone.parse('2010-07-02 23:59:59')).should be_true
-            schedule.occurs_on?(Time.zone.parse('2010-07-03 00:00:01')).should be_false
+            expect(schedule.occurs_on?(Time.zone.parse('2010-07-01 23:59:59'))).to be_false
+            expect(schedule.occurs_on?(Time.zone.parse('2010-07-02 00:00:01'))).to be_true
+            expect(schedule.occurs_on?(Time.zone.parse('2010-07-02 23:59:59'))).to be_true
+            expect(schedule.occurs_on?(Time.zone.parse('2010-07-03 00:00:01'))).to be_false
           end
         end
       end
@@ -719,9 +719,9 @@ describe IceCube::Schedule do
       schedule.add_recurrence_time(Time.local(2010, 7, 12, 16))
       schedule.add_recurrence_time(Time.local(2010, 7, 13, 16))
 
-      schedule.occurs_on?(Date.new(2010, 7, 11)).should be_true
-      schedule.occurs_on?(Date.new(2010, 7, 12)).should be_true
-      schedule.occurs_on?(Date.new(2010, 7, 13)).should be_true
+      expect(schedule.occurs_on?(Date.new(2010, 7, 11))).to be_true
+      expect(schedule.occurs_on?(Date.new(2010, 7, 12))).to be_true
+      expect(schedule.occurs_on?(Date.new(2010, 7, 13))).to be_true
     end
 
   end
@@ -731,14 +731,14 @@ describe IceCube::Schedule do
     schedule.rrule IceCube::Rule.yearly(1)
     occurrence = schedule.next_occurrence
 
-    occurrence.dst?.should == start_time.dst? if start_time.respond_to? :dst?
-    occurrence.utc?.should == start_time.utc? if start_time.respond_to? :utc?
-    occurrence.zone.should == start_time.zone
+    expect(occurrence.dst?).to eq(start_time.dst?) if start_time.respond_to? :dst?
+    expect(occurrence.utc?).to eq(start_time.utc?) if start_time.respond_to? :utc?
+    expect(occurrence.zone).to eq(start_time.zone)
     occurrence.utc_offset == start_time.utc_offset
   end
 
   def trap_infinite_loop_beyond(iterations)
-    IceCube::ValidatedRule.any_instance.should_receive(:finds_acceptable_time?).
+    expect_any_instance_of(IceCube::ValidatedRule).to receive(:finds_acceptable_time?).
                           at_most(iterations).times.and_call_original
   end
 end

--- a/spec/examples/secondly_rule_spec.rb
+++ b/spec/examples/secondly_rule_spec.rb
@@ -4,12 +4,12 @@ module IceCube
   describe SecondlyRule, 'interval validation' do
     it 'converts a string integer to an actual int when using the interval method' do
       rule = Rule.secondly.interval("2")
-      rule.validations_for(:interval).first.interval.should == 2
+      expect(rule.validations_for(:interval).first.interval).to eq(2)
     end
 
     it 'converts a string integer to an actual int when using the initializer' do
       rule = Rule.secondly("3")
-      rule.validations_for(:interval).first.interval.should == 3
+      expect(rule.validations_for(:interval).first.interval).to eq(3)
     end
 
     it 'raises an argument error when a bad value is passed' do

--- a/spec/examples/serialization_spec.rb
+++ b/spec/examples/serialization_spec.rb
@@ -9,7 +9,7 @@ describe IceCube::Schedule do
   describe "::dump(schedule)" do
 
     it "serializes a Schedule object as YAML string" do
-      yaml.should start_with "---\n"
+      expect(yaml).to start_with "---\n"
     end
 
     [nil, ""].each do |blank|
@@ -17,7 +17,7 @@ describe IceCube::Schedule do
         let(:schedule) { blank }
 
         it "returns #{blank.inspect}" do
-          yaml.should be blank
+          expect(yaml).to be blank
         end
       end
     end
@@ -28,7 +28,7 @@ describe IceCube::Schedule do
     let(:new_schedule) { described_class.load yaml }
 
     it "creates a new object from a YAML string" do
-      new_schedule.start_time.to_s.should eq schedule.start_time.to_s
+      expect(new_schedule.start_time.to_s).to eq schedule.start_time.to_s
     end
 
     [nil, ""].each do |blank|
@@ -36,7 +36,7 @@ describe IceCube::Schedule do
         let(:yaml) { blank }
 
         it "returns #{blank.inspect}" do
-          new_schedule.should be blank
+          expect(new_schedule).to be blank
         end
       end
     end

--- a/spec/examples/string_builder_spec.rb
+++ b/spec/examples/string_builder_spec.rb
@@ -5,19 +5,19 @@ describe IceCube::StringBuilder do
   describe :sentence do
 
     it 'should return empty string when none' do
-      IceCube::StringBuilder.sentence([]).should == ''
+      expect(IceCube::StringBuilder.sentence([])).to eq('')
     end
 
     it 'should return sole when one' do
-      IceCube::StringBuilder.sentence(['1']).should == '1'
+      expect(IceCube::StringBuilder.sentence(['1'])).to eq('1')
     end
 
     it 'should split on and when two' do
-      IceCube::StringBuilder.sentence(['1', '2']).should == '1 and 2'
+      expect(IceCube::StringBuilder.sentence(['1', '2'])).to eq('1 and 2')
     end
 
     it 'should comma and when more than two' do
-      IceCube::StringBuilder.sentence(['1', '2', '3']).should == '1, 2, and 3'
+      expect(IceCube::StringBuilder.sentence(['1', '2', '3'])).to eq('1, 2, and 3')
     end
 
   end

--- a/spec/examples/time_util_spec.rb
+++ b/spec/examples/time_util_spec.rb
@@ -5,11 +5,11 @@ module IceCube
 
     describe :wday_to_sym do
       it 'converts 0..6 to weekday symbols' do
-        TimeUtil.wday_to_sym(1).should == :monday
+        expect(TimeUtil.wday_to_sym(1)).to eq(:monday)
       end
 
       it 'returns weekday symbols as is' do
-        TimeUtil.wday_to_sym(:monday).should == :monday
+        expect(TimeUtil.wday_to_sym(:monday)).to eq(:monday)
       end
 
       it 'raises an error for bad input' do
@@ -20,12 +20,12 @@ module IceCube
 
     describe :sym_to_wday do
       it 'converts weekday symbols to 0..6 wday numbers' do
-        TimeUtil.sym_to_wday(:monday).should == 1
+        expect(TimeUtil.sym_to_wday(:monday)).to eq(1)
 
       end
 
       it 'returns wday numbers as is' do
-        TimeUtil.sym_to_wday(1).should == 1
+        expect(TimeUtil.sym_to_wday(1)).to eq(1)
       end
 
       it 'raises an error for bad input' do
@@ -36,11 +36,11 @@ module IceCube
 
     describe :sym_to_month do
       it 'converts month symbols to 1..12 month numbers' do
-        TimeUtil.sym_to_month(:january).should == 1
+        expect(TimeUtil.sym_to_month(:january)).to eq(1)
       end
 
       it 'returns month numbers as is' do
-        TimeUtil.sym_to_month(12).should == 12
+        expect(TimeUtil.sym_to_month(12)).to eq(12)
       end
 
       it 'raises an error for bad input' do

--- a/spec/examples/to_ical_spec.rb
+++ b/spec/examples/to_ical_spec.rb
@@ -5,104 +5,104 @@ describe IceCube, 'to_ical' do
 
   it 'should return a proper ical representation for a basic daily rule' do
     rule = IceCube::Rule.daily
-    rule.to_ical.should == "FREQ=DAILY"
+    expect(rule.to_ical).to eq("FREQ=DAILY")
   end
 
   it 'should return a proper ical representation for a basic monthly rule' do
     rule = IceCube::Rule.weekly
-    rule.to_ical.should == "FREQ=WEEKLY"
+    expect(rule.to_ical).to eq("FREQ=WEEKLY")
   end
 
   it 'should return a proper ical representation for a basic monthly rule' do
     rule = IceCube::Rule.monthly
-    rule.to_ical.should == "FREQ=MONTHLY"
+    expect(rule.to_ical).to eq("FREQ=MONTHLY")
   end
 
   it 'should return a proper ical representation for a basic yearly rule' do
     rule = IceCube::Rule.yearly
-    rule.to_ical.should == "FREQ=YEARLY"
+    expect(rule.to_ical).to eq("FREQ=YEARLY")
   end
 
   it 'should return a proper ical representation for a basic hourly rule' do
     rule = IceCube::Rule.hourly
-    rule.to_ical.should == "FREQ=HOURLY"
+    expect(rule.to_ical).to eq("FREQ=HOURLY")
   end
 
   it 'should return a proper ical representation for a basic minutely rule' do
     rule = IceCube::Rule.minutely
-    rule.to_ical.should == "FREQ=MINUTELY"
+    expect(rule.to_ical).to eq("FREQ=MINUTELY")
   end
 
   it 'should return a proper ical representation for a basic secondly rule' do
     rule = IceCube::Rule.secondly
-    rule.to_ical.should == "FREQ=SECONDLY"
+    expect(rule.to_ical).to eq("FREQ=SECONDLY")
   end
 
   it 'should be able to serialize a .day rule to_ical' do
     rule = IceCube::Rule.daily.day(:monday, :tuesday)
-    rule.to_ical.should == "FREQ=DAILY;BYDAY=MO,TU"
+    expect(rule.to_ical).to eq("FREQ=DAILY;BYDAY=MO,TU")
   end
 
   it 'should be able to serialize a .day_of_week rule to_ical' do
     rule = IceCube::Rule.daily.day_of_week(:tuesday => [-1, -2])
-    rule.to_ical.should == "FREQ=DAILY;BYDAY=-1TU,-2TU"
+    expect(rule.to_ical).to eq("FREQ=DAILY;BYDAY=-1TU,-2TU")
   end
 
   it 'should be able to serialize a .day_of_month rule to_ical' do
     rule = IceCube::Rule.daily.day_of_month(23)
-    rule.to_ical.should == "FREQ=DAILY;BYMONTHDAY=23"
+    expect(rule.to_ical).to eq("FREQ=DAILY;BYMONTHDAY=23")
   end
 
   it 'should be able to serialize a .day_of_year rule to_ical' do
     rule = IceCube::Rule.daily.day_of_year(100,200)
-    rule.to_ical.should == "FREQ=DAILY;BYYEARDAY=100,200"
+    expect(rule.to_ical).to eq("FREQ=DAILY;BYYEARDAY=100,200")
   end
 
   it 'should be able to serialize a .month_of_year rule to_ical' do
     rule = IceCube::Rule.daily.month_of_year(:january, :april)
-    rule.to_ical.should == "FREQ=DAILY;BYMONTH=1,4"
+    expect(rule.to_ical).to eq("FREQ=DAILY;BYMONTH=1,4")
   end
 
   it 'should be able to serialize a .hour_of_day rule to_ical' do
     rule = IceCube::Rule.daily.hour_of_day(10, 20)
-    rule.to_ical.should == "FREQ=DAILY;BYHOUR=10,20"
+    expect(rule.to_ical).to eq("FREQ=DAILY;BYHOUR=10,20")
   end
 
   it 'should be able to serialize a .minute_of_hour rule to_ical' do
     rule = IceCube::Rule.daily.minute_of_hour(5, 55)
-    rule.to_ical.should == "FREQ=DAILY;BYMINUTE=5,55"
+    expect(rule.to_ical).to eq("FREQ=DAILY;BYMINUTE=5,55")
   end
 
   it 'should be able to serialize a .second_of_minute rule to_ical' do
     rule = IceCube::Rule.daily.second_of_minute(0, 15, 30, 45)
-    rule.to_ical.should == "FREQ=DAILY;BYSECOND=0,15,30,45"
+    expect(rule.to_ical).to eq("FREQ=DAILY;BYSECOND=0,15,30,45")
   end
 
   it 'should be able to collapse a combination day_of_week and day' do
     rule = IceCube::Rule.daily.day(:monday, :tuesday).day_of_week(:monday => [1, -1])
-    ['FREQ=DAILY;BYDAY=TU,1MO,-1MO', 'FREQ=DAILY;BYDAY=1MO,-1MO,TU'].include?(rule.to_ical).should be_true
+    expect(['FREQ=DAILY;BYDAY=TU,1MO,-1MO', 'FREQ=DAILY;BYDAY=1MO,-1MO,TU'].include?(rule.to_ical)).to be_true
   end
 
   it 'should be able to serialize of .day_of_week rule to_ical with multiple days' do
     rule = IceCube::Rule.daily.day_of_week(:monday => [1, -1], :tuesday => [2]).day(:wednesday)
-    [
+    expect([
       'FREQ=DAILY;BYDAY=WE,1MO,-1MO,2TU',
       'FREQ=DAILY;BYDAY=1MO,-1MO,2TU,WE',
       'FREQ=DAILY;BYDAY=2TU,1MO,-1MO,WE',
       'FREQ=DAILY;BYDAY=WE,2TU,1MO,-1MO',
       'FREQ=DAILY;BYDAY=2TU,WE,1MO,-1MO'
-    ].include?(rule.to_ical).should be_true
+    ].include?(rule.to_ical)).to be_true
   end
 
   it 'should be able to serialize a base schedule to ical in local time' do
     Time.zone = "Eastern Time (US & Canada)"
     schedule = IceCube::Schedule.new(Time.zone.local(2010, 5, 10, 9, 0, 0))
-    schedule.to_ical.should == "DTSTART;TZID=EDT:20100510T090000"
+    expect(schedule.to_ical).to eq("DTSTART;TZID=EDT:20100510T090000")
   end
 
   it 'should be able to serialize a base schedule to ical in UTC time' do
     schedule = IceCube::Schedule.new(Time.utc(2010, 5, 10, 9, 0, 0))
-    schedule.to_ical.should == "DTSTART:20100510T090000Z"
+    expect(schedule.to_ical).to eq("DTSTART:20100510T090000Z")
   end
 
   it 'should be able to serialize a schedule with one rrule' do
@@ -112,7 +112,7 @@ describe IceCube, 'to_ical' do
     # test equality
     expectation = "DTSTART;TZID=PDT:20100510T090000\n"
     expectation << 'RRULE:FREQ=WEEKLY'
-    schedule.to_ical.should == expectation
+    expect(schedule.to_ical).to eq(expectation)
   end
 
   it 'should be able to serialize a schedule with multiple rrules' do
@@ -123,7 +123,7 @@ describe IceCube, 'to_ical' do
     expectation = "DTSTART;TZID=EDT:20101020T043000\n"
     expectation << "RRULE:FREQ=WEEKLY;BYDAY=2MO,-1MO\n"
     expectation << "RRULE:FREQ=HOURLY"
-    schedule.to_ical.should == expectation
+    expect(schedule.to_ical).to eq(expectation)
   end
 
   it 'should be able to serialize a schedule with one exrule' do
@@ -133,7 +133,7 @@ describe IceCube, 'to_ical' do
     # test equality
     expectation= "DTSTART;TZID=PDT:20100510T090000\n"
     expectation<< 'EXRULE:FREQ=WEEKLY'
-    schedule.to_ical.should == expectation
+    expect(schedule.to_ical).to eq(expectation)
   end
 
   it 'should be able to serialize a schedule with multiple exrules' do
@@ -144,7 +144,7 @@ describe IceCube, 'to_ical' do
     expectation = "DTSTART;TZID=EDT:20101020T043000\n"
     expectation<< "EXRULE:FREQ=WEEKLY;BYDAY=2MO,-1MO\n"
     expectation<< "EXRULE:FREQ=HOURLY"
-    schedule.to_ical.should == expectation
+    expect(schedule.to_ical).to eq(expectation)
   end
 
   it 'should be able to serialize a schedule with an rtime' do
@@ -153,7 +153,7 @@ describe IceCube, 'to_ical' do
     # test equality
     expectation = "DTSTART:20100510T100000Z\n"
     expectation << "RDATE:20100620T050000Z"
-    schedule.to_ical.should == expectation
+    expect(schedule.to_ical).to eq(expectation)
   end
 
   it 'should be able to serialize a schedule with an exception time' do
@@ -162,91 +162,91 @@ describe IceCube, 'to_ical' do
     # test equality
     expectation = "DTSTART:20100510T100000Z\n"
     expectation << "EXDATE:20100620T050000Z"
-    schedule.to_ical.should == expectation
+    expect(schedule.to_ical).to eq(expectation)
   end
 
   it 'should be able to serialize a schedule with a duration' do
     schedule = IceCube::Schedule.new(Time.utc(2010, 5, 10, 10), :duration => 3600)
     expectation = "DTSTART:20100510T100000Z\n"
     expectation << 'DTEND:20100510T110000Z'
-    schedule.to_ical.should == expectation
+    expect(schedule.to_ical).to eq(expectation)
   end
 
   it 'should be able to serialize a schedule with a duration - more odd duration' do
     schedule = IceCube::Schedule.new(Time.utc(2010, 5, 10, 10), :duration => 3665)
     expectation = "DTSTART:20100510T100000Z\n"
     expectation << 'DTEND:20100510T110105Z'
-    schedule.to_ical.should == expectation
+    expect(schedule.to_ical).to eq(expectation)
   end
 
   it 'should be able to serialize a schedule with an end time' do
     schedule = IceCube::Schedule.new(Time.utc(2010, 5, 10, 10), :end_time => Time.utc(2010, 5, 10, 20))
     expectation = "DTSTART:20100510T100000Z\n"
     expectation << "DTEND:20100510T200000Z"
-    schedule.to_ical.should == expectation
+    expect(schedule.to_ical).to eq(expectation)
   end
 
   it 'should not modify the duration when running to_ical' do
     schedule = IceCube::Schedule.new(Time.now, :duration => 3600)
     schedule.to_ical
-    schedule.duration.should == 3600
+    expect(schedule.duration).to eq(3600)
   end
 
   it 'should default to to_ical using local time' do
     time = Time.now
     schedule = IceCube::Schedule.new(Time.now)
-    schedule.to_ical.should == "DTSTART;TZID=#{time.zone}:#{time.strftime('%Y%m%dT%H%M%S')}" # default false
+    expect(schedule.to_ical).to eq("DTSTART;TZID=#{time.zone}:#{time.strftime('%Y%m%dT%H%M%S')}") # default false
   end
 
   it 'should not have an rtime that duplicates start time' do
     start = Time.utc(2012, 12, 12, 12, 0, 0)
     schedule = IceCube::Schedule.new(start)
     schedule.add_recurrence_time start
-    schedule.to_ical.should == "DTSTART:20121212T120000Z"
+    expect(schedule.to_ical).to eq("DTSTART:20121212T120000Z")
   end
 
   it 'should be able to receive a to_ical in utc time' do
     time = Time.now
     schedule = IceCube::Schedule.new(Time.now)
-    schedule.to_ical.should == "DTSTART;TZID=#{time.zone}:#{time.strftime('%Y%m%dT%H%M%S')}" # default false
-    schedule.to_ical(false).should == "DTSTART;TZID=#{time.zone}:#{time.strftime('%Y%m%dT%H%M%S')}"
-    schedule.to_ical(true).should  == "DTSTART:#{time.utc.strftime('%Y%m%dT%H%M%S')}Z"
+    expect(schedule.to_ical).to eq("DTSTART;TZID=#{time.zone}:#{time.strftime('%Y%m%dT%H%M%S')}") # default false
+    expect(schedule.to_ical(false)).to eq("DTSTART;TZID=#{time.zone}:#{time.strftime('%Y%m%dT%H%M%S')}")
+    expect(schedule.to_ical(true)).to  eq("DTSTART:#{time.utc.strftime('%Y%m%dT%H%M%S')}Z")
   end
 
   it 'should be able to serialize to ical with an until date' do
     rule = IceCube::Rule.weekly.until Time.now
-    rule.to_ical.should match /^FREQ=WEEKLY;UNTIL=\d{8}T\d{6}Z$/
+    expect(rule.to_ical).to match /^FREQ=WEEKLY;UNTIL=\d{8}T\d{6}Z$/
   end
 
   it 'should be able to serialize to ical with a count date' do
     rule = IceCube::Rule.weekly.count(5)
-    rule.to_ical.should match /^FREQ=WEEKLY;COUNT=5$/
+    expect(rule.to_ical).to match /^FREQ=WEEKLY;COUNT=5$/
   end
 
   %w{secondly minutely hourly daily monthly yearly}.each do |mthd|
     it "should include intervals for #{mthd} rule" do
       interval = 2
       rule = IceCube::Rule.send(mthd.to_sym, interval)
-      rule.to_ical.should == "FREQ=#{mthd.upcase};INTERVAL=#{interval}"
+      expect(rule.to_ical).to eq("FREQ=#{mthd.upcase};INTERVAL=#{interval}")
     end
   end
 
   it 'should include intervals for weekly rule, including weekstart' do
     interval = 2
     rule = IceCube::Rule.send(:weekly, interval)
-    rule.to_ical.should == "FREQ=WEEKLY;INTERVAL=#{interval};WKST=SU"
+    expect(rule.to_ical).to eq("FREQ=WEEKLY;INTERVAL=#{interval};WKST=SU")
   end
 
   it 'should include intervals for weekly rule, including custom weekstart' do
     interval = 2
     rule = IceCube::Rule.send(:weekly, interval, :monday)
-    rule.to_ical.should == "FREQ=WEEKLY;INTERVAL=#{interval};WKST=MO"
+    expect(rule.to_ical).to eq("FREQ=WEEKLY;INTERVAL=#{interval};WKST=MO")
   end
 
   it 'should not repeat interval when updating rule' do
     rule = IceCube::Rule.weekly
     rule.interval(2)
-    rule.to_ical.should =~ /^FREQ=WEEKLY;INTERVAL=2/
+    expect(rule.to_ical).to match(/^FREQ=WEEKLY;INTERVAL=2/)
   end
 
 end

--- a/spec/examples/to_s_spec.rb
+++ b/spec/examples/to_s_spec.rb
@@ -4,121 +4,123 @@ describe IceCube::Schedule, 'to_s' do
 
   it 'should represent its start time by default' do
     t0 = Time.local(2013, 2, 14)
-    IceCube::Schedule.new(t0).to_s.should == 'February 14, 2013'
+    expect(IceCube::Schedule.new(t0).to_s).to eq('February 14, 2013')
   end
 
   it 'should have a useful base to_s representation for a secondly rule' do
-    IceCube::Rule.secondly.to_s.should == 'Secondly'
-    IceCube::Rule.secondly(2).to_s.should == 'Every 2 seconds'
+    expect(IceCube::Rule.secondly.to_s).to eq('Secondly')
+    expect(IceCube::Rule.secondly(2).to_s).to eq('Every 2 seconds')
   end
 
   it 'should have a useful base to_s representation for a minutely rule' do
-    IceCube::Rule.minutely.to_s.should == 'Minutely'
-    IceCube::Rule.minutely(2).to_s.should == 'Every 2 minutes'
+    expect(IceCube::Rule.minutely.to_s).to eq('Minutely')
+    expect(IceCube::Rule.minutely(2).to_s).to eq('Every 2 minutes')
   end
 
   it 'should have a useful base to_s representation for a hourly rule' do
-    IceCube::Rule.hourly.to_s.should == 'Hourly'
-    IceCube::Rule.hourly(2).to_s.should == 'Every 2 hours'
+    expect(IceCube::Rule.hourly.to_s).to eq('Hourly')
+    expect(IceCube::Rule.hourly(2).to_s).to eq('Every 2 hours')
   end
 
   it 'should have a useful base to_s representation for a daily rule' do
-    IceCube::Rule.daily.to_s.should == 'Daily'
-    IceCube::Rule.daily(2).to_s.should == 'Every 2 days'
+    expect(IceCube::Rule.daily.to_s).to eq('Daily')
+    expect(IceCube::Rule.daily(2).to_s).to eq('Every 2 days')
   end
 
   it 'should have a useful base to_s representation for a weekly rule' do
-    IceCube::Rule.weekly.to_s.should == 'Weekly'
-    IceCube::Rule.weekly(2).to_s.should == 'Every 2 weeks'
+    expect(IceCube::Rule.weekly.to_s).to eq('Weekly')
+    expect(IceCube::Rule.weekly(2).to_s).to eq('Every 2 weeks')
   end
 
   it 'should have a useful base to_s representation for a monthly rule' do
-    IceCube::Rule.monthly.to_s.should == 'Monthly'
-    IceCube::Rule.monthly(2).to_s.should == 'Every 2 months'
+    expect(IceCube::Rule.monthly.to_s).to eq('Monthly')
+    expect(IceCube::Rule.monthly(2).to_s).to eq('Every 2 months')
   end
 
   it 'should have a useful base to_s representation for a yearly rule' do
-    IceCube::Rule.yearly.to_s.should == 'Yearly'
-    IceCube::Rule.yearly(2).to_s.should == 'Every 2 years'
+    expect(IceCube::Rule.yearly.to_s).to eq('Yearly')
+    expect(IceCube::Rule.yearly(2).to_s).to eq('Every 2 years')
   end
 
   it 'should work with various sentence types properly' do
-    IceCube::Rule.weekly.to_s.should == 'Weekly'
-    IceCube::Rule.weekly.day(:monday).to_s.should == 'Weekly on Mondays'
-    IceCube::Rule.weekly.day(:monday, :tuesday).to_s.should == 'Weekly on Mondays and Tuesdays'
-    IceCube::Rule.weekly.day(:monday, :tuesday, :wednesday).to_s.should == 'Weekly on Mondays, Tuesdays, and Wednesdays'
+    expect(IceCube::Rule.weekly.to_s).to eq('Weekly')
+    expect(IceCube::Rule.weekly.day(:monday).to_s).to eq('Weekly on Mondays')
+    expect(IceCube::Rule.weekly.day(:monday, :tuesday).to_s).to eq('Weekly on Mondays and Tuesdays')
+    expect(IceCube::Rule.weekly.day(:monday, :tuesday, :wednesday).to_s).to eq('Weekly on Mondays, Tuesdays, and Wednesdays')
   end
 
   it 'should show saturday and sunday as weekends' do
-    IceCube::Rule.weekly.day(:saturday, :sunday).to_s.should == 'Weekly on Weekends'
+    expect(IceCube::Rule.weekly.day(:saturday, :sunday).to_s).to eq('Weekly on Weekends')
   end
 
   it 'should not show saturday and sunday as weekends when other days are present also' do
-    IceCube::Rule.weekly.day(:sunday, :monday, :saturday).to_s.should ==
+    expect(IceCube::Rule.weekly.day(:sunday, :monday, :saturday).to_s).to eq(
       'Weekly on Sundays, Mondays, and Saturdays'
+    )
   end
 
   it 'should reorganize days to be in order' do
-    IceCube::Rule.weekly.day(:tuesday, :monday).to_s.should ==
+    expect(IceCube::Rule.weekly.day(:tuesday, :monday).to_s).to eq(
       'Weekly on Mondays and Tuesdays'
+    )
   end
 
   it 'should show weekdays as such' do
-    IceCube::Rule.weekly.day(
+    expect(IceCube::Rule.weekly.day(
       :monday, :tuesday, :wednesday,
       :thursday, :friday
-    ).to_s.should == 'Weekly on Weekdays'
+    ).to_s).to eq('Weekly on Weekdays')
   end
 
   it 'should not show weekdays as such when a weekend day is present' do
-    IceCube::Rule.weekly.day(
+    expect(IceCube::Rule.weekly.day(
       :sunday, :monday, :tuesday, :wednesday,
       :thursday, :friday
-    ).to_s.should == 'Weekly on Sundays, Mondays, Tuesdays, Wednesdays, Thursdays, and Fridays'
+    ).to_s).to eq('Weekly on Sundays, Mondays, Tuesdays, Wednesdays, Thursdays, and Fridays')
   end
 
   it 'should show start time for an empty schedule' do
     schedule = IceCube::Schedule.new Time.local(2010, 3, 20)
-    schedule.to_s.should == "March 20, 2010"
+    expect(schedule.to_s).to eq("March 20, 2010")
   end
 
   it 'should work with a single date' do
     schedule = IceCube::Schedule.new Time.local(2010, 3, 20)
     schedule.add_recurrence_time Time.local(2010, 3, 20)
-    schedule.to_s.should == "March 20, 2010"
+    expect(schedule.to_s).to eq("March 20, 2010")
   end
 
   it 'should work with additional dates' do
     schedule = IceCube::Schedule.new Time.local(2010, 3, 20)
     schedule.add_recurrence_time Time.local(2010, 3, 20)
     schedule.add_recurrence_time Time.local(2010, 3, 21)
-    schedule.to_s.should == 'March 20, 2010 / March 21, 2010'
+    expect(schedule.to_s).to eq('March 20, 2010 / March 21, 2010')
   end
 
   it 'should order dates that are out of order' do
     schedule = IceCube::Schedule.new(t0 = Time.local(2010, 3, 20))
     schedule.add_recurrence_time t1 = Time.local(2010, 3, 19)
-    schedule.to_s.should == 'March 19, 2010 / March 20, 2010'
+    expect(schedule.to_s).to eq('March 19, 2010 / March 20, 2010')
   end
 
   it 'should remove duplicated start time' do
     schedule = IceCube::Schedule.new t0 = Time.local(2010, 3, 20)
     schedule.add_recurrence_time t0
-    schedule.to_s.should == 'March 20, 2010'
+    expect(schedule.to_s).to eq('March 20, 2010')
   end
 
   it 'should remove duplicate rtimes' do
     schedule = IceCube::Schedule.new t0 = Time.local(2010, 3, 19)
     schedule.add_recurrence_time Time.local(2010, 3, 20)
     schedule.add_recurrence_time Time.local(2010, 3, 20)
-    schedule.to_s.should == 'March 19, 2010 / March 20, 2010'
+    expect(schedule.to_s).to eq('March 19, 2010 / March 20, 2010')
   end
 
   it 'should work with rules and dates' do
     schedule = IceCube::Schedule.new Time.local(2010, 3, 19)
     schedule.add_recurrence_time Time.local(2010, 3, 20)
     schedule.add_recurrence_rule IceCube::Rule.weekly
-    schedule.to_s.should == 'March 20, 2010 / Weekly'
+    expect(schedule.to_s).to eq('March 20, 2010 / Weekly')
   end
 
   it 'should work with rules and times and exception times' do
@@ -127,76 +129,76 @@ describe IceCube::Schedule, 'to_s' do
     schedule.add_recurrence_time Time.local(2010, 3, 20)
     schedule.add_exception_time Time.local(2010, 3, 20) # ignored
     schedule.add_exception_time Time.local(2010, 3, 21)
-    schedule.to_s.should == 'Weekly / not on March 20, 2010 / not on March 21, 2010'
+    expect(schedule.to_s).to eq('Weekly / not on March 20, 2010 / not on March 21, 2010')
   end
 
   it 'should work with a single rrule' do
     schedule = IceCube::Schedule.new Time.local(2010, 3, 20)
     schedule.add_recurrence_rule IceCube::Rule.weekly.day_of_week(:monday => [1])
-    schedule.to_s.should == schedule.rrules[0].to_s
+    expect(schedule.to_s).to eq(schedule.rrules[0].to_s)
   end
 
   it 'should be able to say the last Thursday of the month' do
     rule_str = IceCube::Rule.monthly.day_of_week(:thursday => [-1]).to_s
-    rule_str.should == 'Monthly on the last Thursday'
+    expect(rule_str).to eq('Monthly on the last Thursday')
   end
 
   it 'should be able to say what months of the year something happens' do
     rule_str = IceCube::Rule.yearly.month_of_year(:june, :july).to_s
-    rule_str.should == 'Yearly in June and July'
+    expect(rule_str).to eq('Yearly in June and July')
   end
 
   it 'should be able to say the second to last monday of the month' do
     rule_str = IceCube::Rule.monthly.day_of_week(:thursday => [-2]).to_s
-    rule_str.should == 'Monthly on the 2nd to last Thursday'
+    expect(rule_str).to eq('Monthly on the 2nd to last Thursday')
   end
 
   it 'should join the first and last weekdays of the month' do
     rule_str = IceCube::Rule.monthly.day_of_week(:thursday => [1, -1]).to_s
-    rule_str.should == 'Monthly on the 1st Thursday and last Thursday'
+    expect(rule_str).to eq('Monthly on the 1st Thursday and last Thursday')
   end
 
   it 'should be able to say the days of the month something happens' do
     rule_str = IceCube::Rule.monthly.day_of_month(1, 15, 30).to_s
-    rule_str.should == 'Monthly on the 1st, 15th, and 30th days of the month'
+    expect(rule_str).to eq('Monthly on the 1st, 15th, and 30th days of the month')
   end
 
   it 'should be able to say what day of the year something happens' do
     rule_str = IceCube::Rule.yearly.day_of_year(30).to_s
-    rule_str.should == 'Yearly on the 30th day of the year'
+    expect(rule_str).to eq('Yearly on the 30th day of the year')
   end
 
   it 'should be able to say what hour of the day something happens' do
     rule_str = IceCube::Rule.daily.hour_of_day(6, 12).to_s
-    rule_str.should == 'Daily on the 6th and 12th hours of the day'
+    expect(rule_str).to eq('Daily on the 6th and 12th hours of the day')
   end
 
   it 'should be able to say what minute of an hour something happens - with special suffix minutes' do
     rule_str = IceCube::Rule.hourly.minute_of_hour(10, 11, 12, 13, 14, 15).to_s
-    rule_str.should == 'Hourly on the 10th, 11th, 12th, 13th, 14th, and 15th minutes of the hour'
+    expect(rule_str).to eq('Hourly on the 10th, 11th, 12th, 13th, 14th, and 15th minutes of the hour')
   end
 
   it 'should be able to say what seconds of the minute something happens' do
     rule_str = IceCube::Rule.minutely.second_of_minute(10, 11).to_s
-    rule_str.should == 'Minutely on the 10th and 11th seconds of the minute'
+    expect(rule_str).to eq('Minutely on the 10th and 11th seconds of the minute')
   end
 
   it 'should be able to reflect until dates' do
     schedule = IceCube::Schedule.new(Time.now)
     schedule.rrule IceCube::Rule.weekly.until(Time.local(2012, 2, 3))
-    schedule.to_s.should == 'Weekly until February  3, 2012'
+    expect(schedule.to_s).to eq('Weekly until February  3, 2012')
   end
 
   it 'should be able to reflect count' do
     schedule = IceCube::Schedule.new(Time.now)
     schedule.add_recurrence_rule IceCube::Rule.weekly.count(1)
-    schedule.to_s.should == 'Weekly 1 time'
+    expect(schedule.to_s).to eq('Weekly 1 time')
   end
 
   it 'should be able to reflect count (proper pluralization)' do
     schedule = IceCube::Schedule.new(Time.now)
     schedule.add_recurrence_rule IceCube::Rule.weekly.count(2)
-    schedule.to_s.should == 'Weekly 2 times'
+    expect(schedule.to_s).to eq('Weekly 2 times')
   end
 
 end

--- a/spec/examples/to_yaml_spec.rb
+++ b/spec/examples/to_yaml_spec.rb
@@ -10,7 +10,7 @@ module IceCube
       it "should make a #{type} round trip with to_yaml [#47]" do
         schedule = Schedule.new(t0 = Time.now)
         schedule.add_recurrence_rule Rule.send(type, 3)
-        Schedule.from_yaml(schedule.to_yaml).first(3).inspect.should == schedule.first(3).inspect
+        expect(Schedule.from_yaml(schedule.to_yaml).first(3).inspect).to eq(schedule.first(3).inspect)
       end
     end
 
@@ -26,7 +26,7 @@ module IceCube
       schedule = Schedule.new(Time.now)
       schedule.add_recurrence_rule Rule.daily.until(Time.now)
       #check assumption
-      schedule.should respond_to('to_yaml')
+      expect(schedule).to respond_to('to_yaml')
     end
 
     it 'should be able to make a round-trip to YAML' do
@@ -40,7 +40,7 @@ module IceCube
       result2 = schedule2.all_occurrences
 
       # compare without usecs
-      result1.map { |r| r.to_s }.should == result2.map { |r| r.to_s }
+      expect(result1.map { |r| r.to_s }).to eq(result2.map { |r| r.to_s })
     end
 
     it 'should be able to make a round-trip to YAML with .day' do
@@ -51,7 +51,7 @@ module IceCube
       schedule2 = Schedule.from_yaml(yaml_string)
 
       # compare without usecs
-      schedule.first(10).map { |r| r.to_s }.should == schedule2.first(10).map { |r| r.to_s }
+      expect(schedule.first(10).map { |r| r.to_s }).to eq(schedule2.first(10).map { |r| r.to_s })
     end
 
     it 'should be able to make a round-trip to YAML with .day_of_month' do
@@ -62,7 +62,7 @@ module IceCube
       schedule2 = Schedule.from_yaml(yaml_string)
 
       # compare without usecs
-      schedule.first(10).map { |r| r.to_s }.should == schedule2.first(10).map { |r| r.to_s }
+      expect(schedule.first(10).map { |r| r.to_s }).to eq(schedule2.first(10).map { |r| r.to_s })
     end
 
     it 'should be able to make a round-trip to YAML with .day_of_week' do
@@ -73,7 +73,7 @@ module IceCube
       schedule2 = Schedule.from_yaml(yaml_string)
 
       # compare without usecs
-      schedule.first(10).map { |r| r.to_s }.should == schedule2.first(10).map { |r| r.to_s }
+      expect(schedule.first(10).map { |r| r.to_s }).to eq(schedule2.first(10).map { |r| r.to_s })
     end
 
     it 'should be able to make a round-trip to YAML with .day_of_year' do
@@ -84,7 +84,7 @@ module IceCube
       schedule2 = Schedule.from_yaml(yaml_string)
 
       # compare without usecs
-      schedule.first(10).map { |r| r.to_s }.should == schedule2.first(10).map { |r| r.to_s }
+      expect(schedule.first(10).map { |r| r.to_s }).to eq(schedule2.first(10).map { |r| r.to_s })
     end
 
     it 'should be able to make a round-trip to YAML with .hour_of_day' do
@@ -95,7 +95,7 @@ module IceCube
       schedule2 = Schedule.from_yaml(yaml_string)
 
       # compare without usecs
-      schedule.first(10).map { |r| r.to_s }.should == schedule2.first(10).map { |r| r.to_s }
+      expect(schedule.first(10).map { |r| r.to_s }).to eq(schedule2.first(10).map { |r| r.to_s })
     end
 
     it 'should be able to make a round-trip to YAML with .minute_of_hour' do
@@ -106,7 +106,7 @@ module IceCube
       schedule2 = Schedule.from_yaml(yaml_string)
 
       # compare without usecs
-      schedule.first(10).map { |r| r.to_s }.should == schedule2.first(10).map { |r| r.to_s }
+      expect(schedule.first(10).map { |r| r.to_s }).to eq(schedule2.first(10).map { |r| r.to_s })
     end
 
     it 'should be able to make a round-trip to YAML with .month_of_year' do
@@ -117,7 +117,7 @@ module IceCube
       schedule2 = Schedule.from_yaml(yaml_string)
 
       # compare without usecs
-      schedule.first(10).map { |r| r.to_s }.should == schedule2.first(10).map { |r| r.to_s }
+      expect(schedule.first(10).map { |r| r.to_s }).to eq(schedule2.first(10).map { |r| r.to_s })
     end
 
     it 'should be able to make a round-trip to YAML with .second_of_minute' do
@@ -128,18 +128,18 @@ module IceCube
       schedule2 = Schedule.from_yaml(yaml_string)
 
       # compare without usecs
-      schedule.first(10).map { |r| r.to_s }.should == schedule2.first(10).map { |r| r.to_s }
+      expect(schedule.first(10).map { |r| r.to_s }).to eq(schedule2.first(10).map { |r| r.to_s })
     end
 
     it 'should have a to_yaml representation of a rule that does not contain ruby objects' do
       rule = Rule.daily.day_of_week(:monday => [1, -1]).month_of_year(:april)
-      rule.to_yaml.include?('object').should be_false
+      expect(rule.to_yaml.include?('object')).to be_false
     end
 
     it 'should have a to_yaml representation of a schedule that does not contain ruby objects' do
       schedule = Schedule.new(Time.now)
       schedule.add_recurrence_rule Rule.daily.day_of_week(:monday => [1, -1]).month_of_year(:april)
-      schedule.to_yaml.include?('object').should be_false
+      expect(schedule.to_yaml.include?('object')).to be_false
     end
 
     # This test will fail when not run in Eastern Time
@@ -150,8 +150,8 @@ module IceCube
       schedule = Schedule.new(start_date)
       schedule = Schedule.from_yaml(schedule.to_yaml) # round trip
       ice_cube_start_date = schedule.start_time
-      ice_cube_start_date.should == start_date
-      ice_cube_start_date.utc_offset.should == start_date.utc_offset
+      expect(ice_cube_start_date).to eq(start_date)
+      expect(ice_cube_start_date.utc_offset).to eq(start_date.utc_offset)
     end
 
     it 'should be able to roll forward times and get back times in an array - Time' do
@@ -159,9 +159,9 @@ module IceCube
       schedule = Schedule.new(start_date)
       schedule = Schedule.from_yaml(schedule.to_yaml) # round trip
       ice_cube_start_date = schedule.start_time
-      ice_cube_start_date.to_s.should == start_date.to_s
-      ice_cube_start_date.class.should == Time
-      ice_cube_start_date.utc_offset.should == start_date.utc_offset
+      expect(ice_cube_start_date.to_s).to eq(start_date.to_s)
+      expect(ice_cube_start_date.class).to eq(Time)
+      expect(ice_cube_start_date.utc_offset).to eq(start_date.utc_offset)
     end
 
     it 'should be able to go back and forth to yaml and then call occurrences' do
@@ -171,14 +171,14 @@ module IceCube
       schedule2 = Schedule.from_yaml(schedule1.to_yaml) # round trip
 
       end_time = Time.now + ONE_DAY
-      schedule1.occurrences(end_time).should == schedule2.occurrences(end_time)
+      expect(schedule1.occurrences(end_time)).to eq(schedule2.occurrences(end_time))
     end
 
     it 'should be able to make a round trip with an exception time' do
       schedule = Schedule.new
       schedule.add_exception_time(time = Time.now)
       schedule = Schedule.from_yaml schedule.to_yaml
-      schedule.extimes.map(&:to_s).should == [time.to_s]
+      expect(schedule.extimes.map(&:to_s)).to eq([time.to_s])
     end
 
     it 'crazy shit' do
@@ -196,33 +196,33 @@ module IceCube
 
     it 'should be able to make a round trip to hash with a duration' do
       schedule = Schedule.new Time.now, :duration => 3600
-      Schedule.from_hash(schedule.to_hash).duration.should == 3600
+      expect(Schedule.from_hash(schedule.to_hash).duration).to eq(3600)
     end
 
     it 'should be able to be serialized to yaml as part of a hash' do
       schedule = Schedule.new Time.now
       hash = { :schedule => schedule }
-      lambda do
+      expect do
         hash.to_yaml
-      end.should_not raise_error
+      end.not_to raise_error
     end
 
     it 'should be able to roll forward and back in time' do
       schedule = Schedule.new(Time.now)
       rt_schedule = Schedule.from_yaml(schedule.to_yaml)
-      rt_schedule.start_time.utc_offset.should == schedule.start_time.utc_offset
+      expect(rt_schedule.start_time.utc_offset).to eq(schedule.start_time.utc_offset)
     end
 
     it 'should be backward compatible with old yaml Time format' do
       pacific_time = 'Pacific Time (US & Canada)'
       yaml = "---\n:end_time:\n:rdates: []\n:rrules: []\n:duration:\n:exdates: []\n:exrules: []\n:start_date: 2010-10-18T14:35:47-07:00"
       schedule = Schedule.from_yaml(yaml)
-      schedule.start_time.should be_a(Time)
+      expect(schedule.start_time).to be_a(Time)
     end
 
     it 'should work to_yaml with non-TimeWithZone' do
       schedule = Schedule.new(Time.now)
-      schedule.to_yaml.length.should be < 200
+      expect(schedule.to_yaml.length).to be < 200
     end
 
     it 'should work with occurs_on and TimeWithZone' do
@@ -230,9 +230,9 @@ module IceCube
       Time.zone = pacific_time
       schedule = Schedule.new(Time.zone.now)
       schedule.add_recurrence_rule Rule.weekly
-      schedule.occurs_on?(schedule.start_time.to_date + 6).should be_false
-      schedule.occurs_on?(schedule.start_time.to_date + 7).should be_true
-      schedule.occurs_on?(schedule.start_time.to_date + 8).should be_false
+      expect(schedule.occurs_on?(schedule.start_time.to_date + 6)).to be_false
+      expect(schedule.occurs_on?(schedule.start_time.to_date + 7)).to be_true
+      expect(schedule.occurs_on?(schedule.start_time.to_date + 8)).to be_false
     end
 
     it 'should work with occurs_on and TimeWithZone' do
@@ -241,9 +241,9 @@ module IceCube
       Time.zone = pacific_time
       schedule = Schedule.new(start_time)
       schedule.add_recurrence_time start_time + 7 * ONE_DAY
-      schedule.occurs_on?(schedule.start_time.to_date + 6).should be_false
-      schedule.occurs_on?(schedule.start_time.to_date + 7).should be_true
-      schedule.occurs_on?(schedule.start_time.to_date + 8).should be_false
+      expect(schedule.occurs_on?(schedule.start_time.to_date + 6)).to be_false
+      expect(schedule.occurs_on?(schedule.start_time.to_date + 7)).to be_true
+      expect(schedule.occurs_on?(schedule.start_time.to_date + 8)).to be_false
     end
 
     it 'should crazy patch' do
@@ -251,9 +251,9 @@ module IceCube
       day = Time.zone.parse('21 Oct 2010 02:00:00')
       schedule = Schedule.new(day)
       schedule.add_recurrence_time(day)
-      schedule.occurs_on?(Date.new(2010, 10, 20)).should be_false
-      schedule.occurs_on?(Date.new(2010, 10, 21)).should be_true
-      schedule.occurs_on?(Date.new(2010, 10, 22)).should be_false
+      expect(schedule.occurs_on?(Date.new(2010, 10, 20))).to be_false
+      expect(schedule.occurs_on?(Date.new(2010, 10, 21))).to be_true
+      expect(schedule.occurs_on?(Date.new(2010, 10, 22))).to be_false
     end
 
     it 'should be able to bring a Rule to_yaml and back with a timezone' do
@@ -262,25 +262,25 @@ module IceCube
       offset = time.utc_offset
       rule = Rule.daily.until(time)
       rule = Rule.from_yaml(rule.to_yaml)
-      rule.until_date.utc_offset.should == offset
+      expect(rule.until_date.utc_offset).to eq(offset)
     end
 
     it 'should be able to bring a Rule to_yaml and back with a count' do
       rule = Rule.daily.count(5)
       rule = Rule.from_yaml rule.to_yaml
-      rule.occurrence_count.should == 5
+      expect(rule.occurrence_count).to eq(5)
     end
 
     it 'should be able to bring a Rule to_yaml and back with an undefined week start' do
       rule = Rule.weekly(2)
       rule = Rule.from_yaml rule.to_yaml
-      rule.week_start.should == :sunday
+      expect(rule.week_start).to eq(:sunday)
     end
 
     it 'should be able to bring a Rule to_yaml and back with a week start defined' do
       rule = Rule.weekly.interval(2, :monday)
       rule = Rule.from_yaml rule.to_yaml
-      rule.week_start.should == :monday
+      expect(rule.week_start).to eq(:monday)
     end
 
     it 'should be able to bring in a schedule with a rule from hash with symbols or strings' do
@@ -290,7 +290,7 @@ module IceCube
 
       symbol_yaml = Schedule.from_hash(symbol_data).to_yaml
       string_yaml = Schedule.from_hash(string_data).to_yaml
-      YAML.load(symbol_yaml).should == YAML.load(string_yaml)
+      expect(YAML.load(symbol_yaml)).to eq(YAML.load(string_yaml))
     end
 
   end

--- a/spec/examples/validated_rule_spec.rb
+++ b/spec/examples/validated_rule_spec.rb
@@ -11,20 +11,20 @@ describe IceCube, "::ValidatedRule" do
         first = Time.new(2013, 2, 25, 0, 0, 0)
         schedule = IceCube::Schedule.new(first)
         schedule.add_recurrence_rule rule
-        rule.next_time(first, schedule, nil).should == first
+        expect(rule.next_time(first, schedule, nil)).to eq(first)
       end
 
       it "Should return the next month when starting one second in the future" do
         first = Time.new(2013, 2, 25, 0, 0, 0)
         schedule = IceCube::Schedule.new(first)
         schedule.add_recurrence_rule rule
-        rule.next_time(first + 1, schedule, nil).should == Time.new(2013, 3, 25, 0, 0, 0)
+        expect(rule.next_time(first + 1, schedule, nil)).to eq(Time.new(2013, 3, 25, 0, 0, 0))
       end
 
       it 'should return the next month near end of longer month [#171]' do
         schedule = IceCube::Schedule.new(Date.new 2013, 1, 1)
         [27, 28, 29, 30, 31].each do |day|
-          rule.next_time(Time.new(2013, 1, day), schedule, nil).should == Time.new(2013, 2, 1)
+          expect(rule.next_time(Time.new(2013, 1, day), schedule, nil)).to eq(Time.new(2013, 2, 1))
         end
       end
 
@@ -38,11 +38,11 @@ describe IceCube, "::ValidatedRule" do
         }
 
         it "should not return the same time on a DST edge when starting one second in the future (results in infinite loop [#98])" do
-          rule.next_time(first + 1, schedule, nil).to_s.should_not == first.to_s
+          expect(rule.next_time(first + 1, schedule, nil).to_s).not_to eq(first.to_s)
         end
 
         it "previous failing test with DST edge taken into account" do
-          rule.next_time(first + 1.hour + 1.second, schedule, nil).to_s.should_not == first.to_s
+          expect(rule.next_time(first + 1.hour + 1.second, schedule, nil).to_s).not_to eq(first.to_s)
         end
       end
 
@@ -53,7 +53,7 @@ describe IceCube, "::ValidatedRule" do
       schedule = double(:start_time => first_time)
       rule = IceCube::Rule.secondly
 
-      rule.next_time(first_time + 1, schedule, nil).should == first_time + 1
+      expect(rule.next_time(first_time + 1, schedule, nil)).to eq(first_time + 1)
     end
   end
 end

--- a/spec/examples/weekly_rule_spec.rb
+++ b/spec/examples/weekly_rule_spec.rb
@@ -4,12 +4,12 @@ module IceCube
   describe WeeklyRule, 'interval validation' do
     it 'converts a string integer to an actual int when using the interval method' do
       rule = Rule.weekly.interval("2")
-      rule.validations_for(:interval).first.interval.should == 2
+      expect(rule.validations_for(:interval).first.interval).to eq(2)
     end
 
     it 'converts a string integer to an actual int when using the initializer' do
       rule = Rule.weekly("3")
-      rule.validations_for(:interval).first.interval.should == 3
+      expect(rule.validations_for(:interval).first.interval).to eq(3)
     end
 
     it 'raises an argument error when a bad value is passed' do

--- a/spec/examples/weekly_rule_spec.rb
+++ b/spec/examples/weekly_rule_spec.rb
@@ -32,21 +32,21 @@ module IceCube
       it 'should include nearest time in DST start hour' do
         schedule = Schedule.new(t0 = Time.local(2013, 3, 3, 2, 30, 0))
         schedule.add_recurrence_rule Rule.weekly
-        schedule.first(3).should == [
+        expect(schedule.first(3)).to eq([
           Time.local(2013, 3,  3, 2, 30, 0), # -0800
           Time.local(2013, 3, 10, 3, 30, 0), # -0700
           Time.local(2013, 3, 17, 2, 30, 0)  # -0700
-        ]
+        ])
       end
 
       it 'should not skip times in DST end hour' do
         schedule = Schedule.new(t0 = Time.local(2013, 10, 27, 2, 30, 0))
         schedule.add_recurrence_rule Rule.weekly
-        schedule.first(3).should == [
+        expect(schedule.first(3)).to eq([
           Time.local(2013, 10, 27, 2, 30, 0), # -0700
           Time.local(2013, 11,  3, 2, 30, 0), # -0700
           Time.local(2013, 11, 10, 2, 30, 0)  # -0800
-        ]
+        ])
       end
 
     end
@@ -55,7 +55,7 @@ module IceCube
       schedule = double(start_time: t0 = Time.new(2013, 1, 1))
       rule = Rule.weekly(7)
       rule.interval(2)
-      rule.next_time(t0 + 1, schedule, nil).should == Time.new(2013, 1, 15)
+      expect(rule.next_time(t0 + 1, schedule, nil)).to eq(Time.new(2013, 1, 15))
     end
 
     it 'should produce the correct number of days for @interval = 1 with no weekdays specified' do
@@ -63,38 +63,38 @@ module IceCube
       schedule.add_recurrence_rule Rule.weekly
       #check assumption (2 weeks in the future) (1) (2) (3) (4) (5)
       times = schedule.occurrences(t0 + (7 * 3 + 1) * ONE_DAY)
-      times.size.should == 4
+      expect(times.size).to eq(4)
     end
 
     it 'should produce the correct number of days for @interval = 1 with only weekends' do
       schedule = Schedule.new(t0 = WEDNESDAY)
       schedule.add_recurrence_rule Rule.weekly.day(:saturday, :sunday)
       #check assumption
-      schedule.occurrences(t0 + 4 * ONE_WEEK).size.should == 8
+      expect(schedule.occurrences(t0 + 4 * ONE_WEEK).size).to eq(8)
     end
 
     it 'should set days from symbol args' do
       schedule = Schedule.new(t0 = WEDNESDAY)
       schedule.add_recurrence_rule Rule.weekly.day(:monday, :wednesday)
-      schedule.rrules.first.validations_for(:day).map(&:day).should == [1, 3]
+      expect(schedule.rrules.first.validations_for(:day).map(&:day)).to eq([1, 3])
     end
 
     it 'should set days from array of symbols' do
       schedule = Schedule.new(t0 = WEDNESDAY)
       schedule.add_recurrence_rule Rule.weekly.day([:monday, :wednesday])
-      schedule.rrules.first.validations_for(:day).map(&:day).should == [1, 3]
+      expect(schedule.rrules.first.validations_for(:day).map(&:day)).to eq([1, 3])
     end
 
     it 'should set days from integer args' do
       schedule = Schedule.new(t0 = WEDNESDAY)
       schedule.add_recurrence_rule Rule.weekly.day(1, 3)
-      schedule.rrules.first.validations_for(:day).map(&:day).should == [1, 3]
+      expect(schedule.rrules.first.validations_for(:day).map(&:day)).to eq([1, 3])
     end
 
     it 'should set days from array of integers' do
       schedule = Schedule.new(t0 = WEDNESDAY)
       schedule.add_recurrence_rule Rule.weekly.day([1, 3])
-      schedule.rrules.first.validations_for(:day).map(&:day).should == [1, 3]
+      expect(schedule.rrules.first.validations_for(:day).map(&:day)).to eq([1, 3])
     end
 
     it 'should raise an error on invalid input' do
@@ -107,7 +107,7 @@ module IceCube
       schedule.add_recurrence_rule Rule.weekly(2).day(:wednesday)
       #check assumption
       times = schedule.occurrences(t0 + 3 * ONE_WEEK)
-      times.should == [t0, t0 + 2 * ONE_WEEK]
+      expect(times).to eq([t0, t0 + 2 * ONE_WEEK])
     end
 
     it 'should produce the correct days for @interval = 2, regardless of the start week' do
@@ -115,46 +115,46 @@ module IceCube
       schedule.add_recurrence_rule Rule.weekly(2).day(:wednesday)
       #check assumption
       times = schedule.occurrences(t0 + 3 * ONE_WEEK)
-      times.should == [t0, t0 + 2 * ONE_WEEK]
+      expect(times).to eq([t0, t0 + 2 * ONE_WEEK])
     end
 
     it 'should occur every 2nd tuesday of a month' do
       schedule = Schedule.new(t0 = Time.now)
       schedule.add_recurrence_rule Rule.monthly.hour_of_day(11).day_of_week(:tuesday => [2])
       schedule.first(48).each do |d|
-        d.hour.should == 11
-        d.wday.should == 2
+        expect(d.hour).to eq(11)
+        expect(d.wday).to eq(2)
       end
     end
 
     it 'should be able to start on sunday but repeat on wednesdays' do
       schedule = Schedule.new(t0 = Time.local(2010, 8, 1))
       schedule.add_recurrence_rule Rule.weekly.day(:monday)
-      schedule.first(3).should == [
+      expect(schedule.first(3)).to eq([
         Time.local(2010, 8,  2),
         Time.local(2010, 8,  9),
         Time.local(2010, 8, 16)
-      ]
+      ])
     end
 
     it 'should start weekly rules on monday when monday is the week start' do
       schedule = Schedule.new(t0 = Time.local(2012, 2, 7))
       schedule.add_recurrence_rule Rule.weekly(2, :monday).day(:tuesday, :sunday)
-      schedule.first(3).should == [
+      expect(schedule.first(3)).to eq([
         Time.local(2012, 2,  7),
         Time.local(2012, 2, 12),
         Time.local(2012, 2, 21)
-      ]
+      ])
     end
 
     it 'should start weekly rules on sunday by default' do
       schedule = Schedule.new(t0 = Time.local(2012,2,7))
       schedule.add_recurrence_rule Rule.weekly(2).day(:tuesday, :sunday)
-      schedule.first(3).should == [
+      expect(schedule.first(3)).to eq([
         Time.local(2012, 2,  7),
         Time.local(2012, 2, 19),
         Time.local(2012, 2, 21)
-      ]
+      ])
     end
 
     it 'should validate week_start input' do

--- a/spec/examples/yearly_rule_spec.rb
+++ b/spec/examples/yearly_rule_spec.rb
@@ -3,12 +3,12 @@ require File.dirname(__FILE__) + '/../spec_helper'
 describe IceCube::YearlyRule, 'interval validation' do
   it 'converts a string integer to an actual int when using the interval method' do
     rule = Rule.yearly.interval("2")
-    rule.validations_for(:interval).first.interval.should == 2
+    expect(rule.validations_for(:interval).first.interval).to eq(2)
   end
 
   it 'converts a string integer to an actual int when using the initializer' do
     rule = Rule.yearly("3")
-    rule.validations_for(:interval).first.interval.should == 3
+    expect(rule.validations_for(:interval).first.interval).to eq(3)
   end
 
   it 'raises an argument error when a bad value is passed' do

--- a/spec/examples/yearly_rule_spec.rb
+++ b/spec/examples/yearly_rule_spec.rb
@@ -31,7 +31,7 @@ describe IceCube::YearlyRule, 'occurs_on?' do
     schedule = double(start_time: t0 = Time.utc(2013, 5, 1))
     rule = Rule.yearly(3)
     rule.interval(1)
-    rule.next_time(t0 + 1, schedule, nil).should == t0 + 365.days
+    expect(rule.next_time(t0 + 1, schedule, nil)).to eq(t0 + 365.days)
   end
 
   it 'should be able to specify complex yearly rules' do
@@ -39,7 +39,7 @@ describe IceCube::YearlyRule, 'occurs_on?' do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.yearly.month_of_year(:april).day_of_week(:monday => [1, -1])
     #check assumption - over 1 year should be 2
-    schedule.occurrences(start_date + IceCube::TimeUtil.days_in_year(start_date) * IceCube::ONE_DAY).size.should == 2
+    expect(schedule.occurrences(start_date + IceCube::TimeUtil.days_in_year(start_date) * IceCube::ONE_DAY).size).to eq(2)
   end
 
   it 'should produce the correct number of days for @interval = 1' do
@@ -47,7 +47,7 @@ describe IceCube::YearlyRule, 'occurs_on?' do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.yearly
     #check assumption
-    schedule.occurrences(start_date + 370 * IceCube::ONE_DAY).size.should == 2
+    expect(schedule.occurrences(start_date + 370 * IceCube::ONE_DAY).size).to eq(2)
   end
 
   it 'should produce the correct number of days for @interval = 2' do
@@ -55,7 +55,7 @@ describe IceCube::YearlyRule, 'occurs_on?' do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.yearly(2)
     #check assumption
-    schedule.occurrences(start_date + 370 * IceCube::ONE_DAY).should == [start_date]
+    expect(schedule.occurrences(start_date + 370 * IceCube::ONE_DAY)).to eq([start_date])
   end
 
   it 'should produce the correct number of days for @interval = 1 when you specify months' do
@@ -63,7 +63,7 @@ describe IceCube::YearlyRule, 'occurs_on?' do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.yearly.month_of_year(:january, :april, :november)
     #check assumption
-    schedule.occurrences(Time.utc(2010, 12, 31)).size.should == 3
+    expect(schedule.occurrences(Time.utc(2010, 12, 31)).size).to eq(3)
   end
 
   it 'should produce the correct number of days for @interval = 1 when you specify days' do
@@ -71,14 +71,14 @@ describe IceCube::YearlyRule, 'occurs_on?' do
     schedule = IceCube::Schedule.new(start_date)
     schedule.add_recurrence_rule IceCube::Rule.yearly.day_of_year(155, 200)
     #check assumption
-    schedule.occurrences(Time.utc(2010, 12, 31)).size.should == 2
+    expect(schedule.occurrences(Time.utc(2010, 12, 31)).size).to eq(2)
   end
 
   it 'should produce the correct number of days for @interval = 1 when you specify negative days' do
     schedule = IceCube::Schedule.new(Time.utc(2010, 1, 1))
     schedule.add_recurrence_rule IceCube::Rule.yearly.day_of_year(100, -1)
     #check assumption
-    schedule.occurrences(Time.utc(2010, 12, 31)).size.should == 2
+    expect(schedule.occurrences(Time.utc(2010, 12, 31)).size).to eq(2)
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,8 +44,8 @@ RSpec.configure do |config|
   config.before :each do
     if time_args = @example.metadata[:system_time]
       case time_args
-      when Array then Time.stub!(:now).and_return Time.local(*time_args)
-      when Time  then Time.stub!(:now).and_return time_args
+      when Array then allow(Time).to receive(:now).and_return Time.local(*time_args)
+      when Time  then allow(Time).to receive(:now).and_return time_args
       end
     end
   end


### PR DESCRIPTION
1. Fixed gemspec to load by using 'activesupport'
2. Updated gemspec to allow more recent versions of RSpec
3. Ran transpec to update specs to RSpec 3.x syntax
