### PR TITLE
HashParser#schedule handles a nil value for @hash

### DIFF
--- a/lib/ice_cube/parsers/hash_parser.rb
+++ b/lib/ice_cube/parsers/hash_parser.rb
@@ -8,7 +8,7 @@ module IceCube
     end
 
     def to_schedule
-      data = normalize_keys(hash)
+      data = normalize_keys(hash || {})
       schedule = IceCube::Schedule.new parse_time(data[:start_time])
       apply_duration schedule, data
       apply_end_time schedule, data

--- a/spec/examples/hash_parser_spec.rb
+++ b/spec/examples/hash_parser_spec.rb
@@ -17,6 +17,18 @@ module IceCube
         let(:hash) { {start_time: t, end_time: t + 1800, duration: 3600} }
         its(:duration) { should == 1800 }
       end
+
+      describe "with an initial nil" do
+        let(:hash) { nil }
+
+        it 'has no recurrence rules' do
+          schedule.recurrence_rules.should be_empty
+        end
+
+        it 'has no exception rules' do
+          schedule.exception_rules.should be_empty
+        end
+      end
     end
 
 


### PR DESCRIPTION
In a Rails application I'm serializing an attribute, `schedule`, using the `Icecube::Schedule` class. I'm unable to load any objects where the `schedule` has not been set, i.e. it has a `nil` value. This is due to a `TypeError` that occurs within `HashParser#to_schedule` method. 

When Rails attempts to load an ActiveRecord object that has a serialized `IceCube::Schedule` class it calls `IceCube::Schedule.load`, https://github.com/wallace/ice_cube/blob/master/lib/ice_cube/schedule.rb#L386.  The call chain eventually calls `HashParser#to_schedule`, https://github.com/wallace/ice_cube/blob/master/lib/ice_cube/schedule.rb#L343 with a `nil` value for `@hash` which results in a `TypeError` "can't dup NilClass" when `HashParser` attempts to normalize the keys.

This pull request ensures that `to_schedule` handles a `nil` value in the `@hash` by default to an empty hash when `@hash` is `nil`. I'd prefer to use `to_h` but that's not available in Ruby 1.9.3. :(
