### PR TITLE
HashParser defaults to a hash when passed a nil value

### DIFF
--- a/lib/ice_cube/parsers/hash_parser.rb
+++ b/lib/ice_cube/parsers/hash_parser.rb
@@ -4,7 +4,7 @@ module IceCube
     attr_reader :hash
 
     def initialize(original_hash)
-      @hash = original_hash
+      @hash = original_hash || {}
     end
 
     def to_schedule

--- a/spec/examples/hash_parser_spec.rb
+++ b/spec/examples/hash_parser_spec.rb
@@ -17,9 +17,16 @@ module IceCube
         let(:hash) { {start_time: t, end_time: t + 1800, duration: 3600} }
         its(:duration) { should == 1800 }
       end
+
+      describe 'when passed a nil value' do
+        it 'does not raise an error' do
+          expect {
+            IceCube::HashParser.new(nil).to_schedule.should
+          }.not_to raise_error
+        end
+      end
     end
 
 
   end
 end
-


### PR DESCRIPTION
When init-ing a `HashParser` with a nil value, the following error is thrown when calling `to_schedule`: `TypeError: can't dup NilClass`.

This PR fixes that by ensuring a hash value is initialized if a nil value is passed.
