### PR TITLE
next_occurrences should respect the end_time

### DIFF
--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -400,7 +400,7 @@ module IceCube
     # Iteration is unrolled in pairs to skip duplicate times in end of DST
     def enumerate_occurrences(opening_time, closing_time = nil, &block)
       opening_time = TimeUtil.match_zone(opening_time, start_time)
-      closing_time = TimeUtil.match_zone(closing_time, start_time)
+      closing_time = TimeUtil.match_zone((closing_time || end_time), start_time)
       opening_time += start_time.subsec - opening_time.subsec rescue 0
       reset
       opening_time = start_time if opening_time < start_time

--- a/spec/examples/schedule_spec.rb
+++ b/spec/examples/schedule_spec.rb
@@ -354,6 +354,14 @@ describe IceCube::Schedule do
 
     let(:nonsense) { IceCube::Rule.monthly.day_of_week(:monday => [1]).day_of_month(31) }
 
+    it 'should respect the end_time' do
+      st = Time.now
+      et = Time.now + 120
+      schedule = IceCube::Schedule.new(st, end_time: et)
+      schedule.rrule IceCube::Rule.minutely
+      schedule.next_occurrences(5).size.should == 2
+    end
+
     it 'should be able to calculate next occurrences ignoring excluded times' do
       start_time = Time.now
       schedule = IceCube::Schedule.new start_time


### PR DESCRIPTION
Not sure if this is intended behavior or a bug, but it seemed like a bug, so here's a patch ;)
