### PR TITLE
arity is -1 for ActiveSupport::TimeWithZone.to_s, so only check for arit...

### DIFF
--- a/lib/ice_cube/occurrence.rb
+++ b/lib/ice_cube/occurrence.rb
@@ -84,7 +84,7 @@ module IceCube
     # time formats and is only used when ActiveSupport is available.
     #
     def to_s(format=nil)
-      if format && to_time.public_method(:to_s).arity > 0
+      if format && to_time.public_method(:to_s).arity != 0
         t0, t1 = start_time.to_s(format), end_time.to_s(format)
       else
         t0, t1 = start_time.to_s, end_time.to_s

--- a/spec/examples/occurrence_spec.rb
+++ b/spec/examples/occurrence_spec.rb
@@ -28,9 +28,11 @@ describe Occurrence do
     end
 
     it "accepts a format option to comply with ActiveSupport" do
-      occurrence = Occurrence.new(Time.now)
+      require 'active_support/core_ext/time'
+      time_now = Time.current
+      occurrence = Occurrence.new(time_now)
 
-      expect { occurrence.to_s(:short) }.not_to raise_error
+      expect(occurrence.to_s(:short)).to eq time_now.to_s(:short)
     end
   end
 


### PR DESCRIPTION
...y != 0

fixes issue where format is not interpreted by and used by `Occurrence` properly.
