### PR TITLE
Fix WEEKLY recurring when specifying non default WKST

### DIFF
--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -498,17 +498,13 @@ module IceCube
     # of week N-1, the first jump would go to end of week N and miss any
     # earlier validations in the week). This realigns the opening time to
     # the start of the interval's correct period (e.g. move to start of week N)
-    # TODO: check if this is needed for validations other than `:wday`
     #
+    # Should only apply to WeeklyRule, use wkst as place to go back to
     def realign(opening_time)
       time = TimeUtil::TimeWrapper.new(opening_time)
       recurrence_rules.each do |rule|
-        wday_validations = rule.other_interval_validations.select { |v| v.type == :wday } or next
-        interval = rule.base_interval_validation.validate(opening_time, self).to_i
-        offset = wday_validations
-          .map { |v| v.validate(opening_time, self).to_i }
-          .reduce(0) { |least, i| i > 0 && i <= interval && (i < least || least == 0) ? i : least }
-        time.add(rule.base_interval_type, 7 - time.to_time.wday) if offset > 0
+        next unless rule.respond_to?(:week_start)
+        time.add(rule.base_interval_type, TimeUtil.sym_to_wday(rule.week_start) - time.to_time.wday)
       end
       time.to_time
     end


### PR DESCRIPTION
fixes a nasty edge case where we advance past the start of the opening_time and miss occurrences.
