### PR TITLE
Adding namespacing to Rule in Readme to make it easier to run examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ With ice_cube, you can specify (in increasing order of precedence):
 * Recurrence Times - To specifically include in a schedule
 * Exception Times - To specifically exclude from a schedule
 
-Example: Specifying a recurrence with an exception time (ActiveRecord:
+Example: Specifying a recurrence with an exception time
 
 ```ruby
 schedule = IceCube::Schedule.new(now = Time.now) do |s|

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Imagine you want:
 You would write:
 
 ```ruby
+schedule = IceCube::Schedule.new
 schedule.add_recurrence_rule(
-  Rule.yearly.day_of_month(13).day(:friday).month_of_year(:october)
+  IceCube::Rule.yearly.day_of_month(13).day(:friday).month_of_year(:october)
 )
 ```
 
@@ -42,11 +43,11 @@ With ice_cube, you can specify (in increasing order of precedence):
 * Recurrence Times - To specifically include in a schedule
 * Exception Times - To specifically exclude from a schedule
 
-Example: Specifying a recurrence with an exception time:
+Example: Specifying a recurrence with an exception time (ActiveRecord:
 
 ```ruby
 schedule = IceCube::Schedule.new(now = Time.now) do |s|
-  s.add_recurrence_rule(Rule.daily.count(3))
+  s.add_recurrence_rule(IceCube::Rule.daily.count(3))
   s.add_exception_time(now + 1.day)
 end
 
@@ -87,13 +88,13 @@ schedule.previous_occurrences(3, from_time)
 
 # or give the schedule a duration and ask if occurring_at?
 schedule = IceCube::Schedule.new(now, :duration => 3600)
-schedule.add_recurrence_rule Rule.daily
+schedule.add_recurrence_rule IceCube::Rule.daily
 schedule.occurring_at?(now + 1800) # true
 schedule.occurring_between?(t1, t2)
 
-# using end_time also sets the duration 
+# using end_time also sets the duration
 schedule = IceCube::Schedule.new(start = Time.now, :end_time => start + 3600)
-schedule.add_recurrence_rule Rule.daily
+schedule.add_recurrence_rule IceCube::Rule.daily
 schedule.occurring_at?(start + 3599) # true
 schedule.occurring_at?(start + 3600) # false
 
@@ -170,36 +171,36 @@ There are many types of recurrence rules that can be added to a schedule:
 
 ```ruby
 # every day
-schedule.add_recurrence_rule Rule.daily
+schedule.add_recurrence_rule IceCube::Rule.daily
 
 # every third day
-schedule.add_recurrence_rule Rule.daily(3)
+schedule.add_recurrence_rule IceCube::Rule.daily(3)
 ```
 
 ### Weekly
 
 ```ruby
 # every week
-schedule.add_recurrence_rule Rule.weekly
+schedule.add_recurrence_rule IceCube::Rule.weekly
 
 # every other week on monday and tuesday
-schedule.add_recurrence_rule Rule.weekly(2).day(:monday, :tuesday)
+schedule.add_recurrence_rule IceCube::Rule.weekly(2).day(:monday, :tuesday)
 
 # for programmatic convenience (same as above)
-schedule.add_recurrence_rule Rule.weekly(2).day(1, 2)
+schedule.add_recurrence_rule IceCube::Rule.weekly(2).day(1, 2)
 
 # specifying a weekly interval with a different first weekday (defaults to Sunday)
-schedule.add_recurrence_rule Rule.weekly(1, :monday)
+schedule.add_recurrence_rule IceCube::Rule.weekly(1, :monday)
 ```
 
 ### Monthly (by day of month)
 
 ```ruby
 # every month on the first and last days of the month
-schedule.add_recurrence_rule Rule.monthly.day_of_month(1, -1)
+schedule.add_recurrence_rule IceCube::Rule.monthly.day_of_month(1, -1)
 
 # every other month on the 15th of the month
-schedule.add_recurrence_rule Rule.monthly(2).day_of_month(15)
+schedule.add_recurrence_rule IceCube::Rule.monthly(2).day_of_month(15)
 ```
 
 Monthly rules will skip months that are too short for the specified day of
@@ -209,69 +210,69 @@ month (e.g. no occurrences in February for `day_of_month(31)`).
 
 ```ruby
 # every month on the first and last tuesdays of the month
-schedule.add_recurrence_rule Rule.monthly.day_of_week(:tuesday => [1, -1])
+schedule.add_recurrence_rule IceCube::Rule.monthly.day_of_week(:tuesday => [1, -1])
 
 # every other month on the first monday and last tuesday
-schedule.add_recurrence_rule Rule.monthly(2).day_of_week(
+schedule.add_recurrence_rule IceCube::Rule.monthly(2).day_of_week(
   :monday => [1],
   :tuesday => [-1]
 )
 
 # for programmatic convenience (same as above)
-schedule.add_recurrence_rule Rule.monthly(2).day_of_week(1 => [1], 2 => [-1])
+schedule.add_recurrence_rule IceCube::Rule.monthly(2).day_of_week(1 => [1], 2 => [-1])
 ```
 
 ### Yearly (by day of year)
 
 ```ruby
 # every year on the 100th days from the beginning and end of the year
-schedule.add_recurrence_rule Rule.yearly.day_of_year(100, -100)
+schedule.add_recurrence_rule IceCube::Rule.yearly.day_of_year(100, -100)
 
 # every fourth year on new year's eve
-schedule.add_recurrence_rule Rule.yearly(4).day_of_year(-1)
+schedule.add_recurrence_rule IceCube::Rule.yearly(4).day_of_year(-1)
 ```
 
 ### Yearly (by month of year)
 
 ```ruby
 # every year on the same day as start_time but in january and february
-schedule.add_recurrence_rule Rule.yearly.month_of_year(:january, :februrary)
+schedule.add_recurrence_rule IceCube::Rule.yearly.month_of_year(:january, :februrary)
 
 # every third year in march
-schedule.add_recurrence_rule Rule.yearly(3).month_of_year(:march)
+schedule.add_recurrence_rule IceCube::Rule.yearly(3).month_of_year(:march)
 
 # for programatic convenience (same as above)
-schedule.add_recurrence_rule Rule.yearly(3).month_of_year(3)
+schedule.add_recurrence_rule IceCube::Rule.yearly(3).month_of_year(3)
 ```
 
 ### Hourly (by hour of day)
 
 ```ruby
 # every hour on the same minute and second as start date
-schedule.add_recurrence_rule Rule.hourly
+schedule.add_recurrence_rule IceCube::Rule.hourly
 
 # every other hour, on mondays
-schedule.add_recurrence_rule Rule.hourly(2).day(:monday)
+schedule.add_recurrence_rule IceCube::Rule.hourly(2).day(:monday)
 ```
 
 ### Minutely (every N minutes)
 
 ```ruby
 # every 10 minutes
-schedule.add_recurrence_rule Rule.minutely(10)
+schedule.add_recurrence_rule IceCube::Rule.minutely(10)
 
 # every hour and a half, on the last tuesday of the month
-schedule.add_recurrence_rule Rule.minutely(90).day_of_week(:tuesday => [-1])
+schedule.add_recurrence_rule IceCube::Rule.minutely(90).day_of_week(:tuesday => [-1])
 ```
 
 ### Secondly (every N seconds)
 
 ```ruby
 # every second
-schedule.add_recurrence_rule Rule.secondly
+schedule.add_recurrence_rule IceCube::Rule.secondly
 
 # every 15 seconds between 12:00 - 12:59
-schedule.add_recurrence_rule Rule.secondly(15).hour_of_day(12)
+schedule.add_recurrence_rule IceCube::Rule.secondly(15).hour_of_day(12)
 ```
 
 ---


### PR DESCRIPTION
While experimenting with this library with my team I ran into the inconvenience that some of the usages of Rule in the readme are namespaced to IceCube:: and some are not, so here is a PR. :space_invader: 