### PR TITLE
Fxes issue #303 preventing multiple rule parsing

### DIFF
--- a/lib/ice_cube/parsers/ical_parser.rb
+++ b/lib/ice_cube/parsers/ical_parser.rb
@@ -16,7 +16,8 @@ module IceCube
         when 'DURATION'
           data[:duration] # FIXME
         when 'RRULE'
-          data[:rrules] = [rule_from_ical(value)]
+          data[:rrules] ||= []
+          data[:rrules] << rule_from_ical(value)
         end
       end
       Schedule.from_hash data

--- a/spec/examples/from_ical_spec.rb
+++ b/spec/examples/from_ical_spec.rb
@@ -363,6 +363,12 @@ module IceCube
         schedule.exception_times.count.should == 3
       end
     end
-  end
 
+    it 'parses multiple rules' do
+      source = "DTSTART;TZID=CDT:20151005T185038\nRRULE:FREQ=WEEKLY;BYDAY=MO" \
+               ",TU\nRRULE:FREQ=WEEKLY;INTERVAL=2;WKST=SU;BYDAY=FR"
+      schedule = IceCube::Schedule.from_ical(source)
+      expect(schedule.recurrence_rules.size).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
See issue #303 for example, just a simple fix to add elements to an array in the hash key rather than assigning a new array every time a rule was processed.
