### PR TITLE
Parse incoming RDATE lines from iCal files, handle all-day RDATE and EXDATE

### DIFF
--- a/lib/ice_cube/builders/ical_builder.rb
+++ b/lib/ice_cube/builders/ical_builder.rb
@@ -35,12 +35,20 @@ module IceCube
       IceCube::I18n.l(time, format: '%Y%m%dT%H%M%SZ') # utc time
     end
 
-    def self.ical_format(time, force_utc)
+    def self.ical_format(time, force_utc, rule=nil)
       time = time.dup.utc if force_utc
-      if time.utc?
-        ":#{IceCube::I18n.l(time, format: '%Y%m%dT%H%M%SZ')}" # utc time
+      if rule && rule.whole_day?
+        result = ";VALUE=DATE"
+        hms = ""
       else
-        ";TZID=#{IceCube::I18n.l(time, format: '%Z:%Y%m%dT%H%M%S')}" # local time specified
+        result = ""
+        hms = "T%H%M%S"
+        time.utc? and hms << "Z"
+      end
+      if time.utc?
+        result << ":#{IceCube::I18n.l(time, format: "%Y%m%d#{hms}")}" # utc time
+      else
+        result << ";TZID=#{IceCube::I18n.l(time, format: "%Z:%Y%m%d#{hms}")}" # local time specified
       end
     end
 

--- a/lib/ice_cube/parsers/hash_parser.rb
+++ b/lib/ice_cube/parsers/hash_parser.rb
@@ -70,16 +70,16 @@ module IceCube
     end
 
     def apply_rtimes(schedule, data)
-      return unless data[:rtimes]
-      data[:rtimes].each do |t|
-        schedule.add_recurrence_time TimeUtil.deserialize_time(t)
+      return unless data[:rtimes_infos]
+      data[:rtimes_infos].each do |info|
+        schedule.add_recurrence_time(TimeUtil.deserialize_time(info.time_value), info.whole_day)
       end
     end
 
     def apply_extimes(schedule, data)
-      return unless data[:extimes]
-      data[:extimes].each do |t|
-        schedule.add_exception_time TimeUtil.deserialize_time(t)
+      return unless data[:extimes_infos]
+      data[:extimes_infos].each do |info|
+        schedule.add_exception_time(TimeUtil.deserialize_time(info.time_value), info.whole_day)
       end
     end
 

--- a/lib/ice_cube/parsers/ical_parser.rb
+++ b/lib/ice_cube/parsers/ical_parser.rb
@@ -17,6 +17,9 @@ module IceCube
           data[:duration] # FIXME
         when 'RRULE'
           data[:rrules] = [rule_from_ical(value)]
+        when 'RDATE'
+          data[:rtimes] ||= []
+          data[:rtimes] += value.split(',').map{|v| Time.parse(v)}
         end
       end
       Schedule.from_hash data

--- a/lib/ice_cube/single_occurrence_rule.rb
+++ b/lib/ice_cube/single_occurrence_rule.rb
@@ -13,6 +13,20 @@ module IceCube
       true
     end
 
+    # Override from Rule, so any RDATE or EXDATE values may be used without HH:MM:SS defined.
+    #
+    def on?(time, schedule)
+      next_time(time, schedule, time).to_i == time.to_i || whole_day? && same_day?(time)
+    end
+
+    def whole_day?
+      time.hour == 0 && time.min == 0 && time.sec == 0
+    end
+
+    def same_day?(other)
+      time.year == other.year && time.month == other.month && time.day == other.day
+    end
+
     def next_time(t, schedule, closing_time)
       unless closing_time && closing_time < t
         time if time.to_i >= t.to_i

--- a/lib/ice_cube/single_occurrence_rule.rb
+++ b/lib/ice_cube/single_occurrence_rule.rb
@@ -4,8 +4,9 @@ module IceCube
 
     attr_reader :time
 
-    def initialize(time)
+    def initialize(time, whole_day=false)
       @time = TimeUtil.ensure_time time
+      @whole_day = whole_day
     end
 
     # Always terminating
@@ -13,14 +14,14 @@ module IceCube
       true
     end
 
-    # Override from Rule, so any RDATE or EXDATE values may be used without HH:MM:SS defined.
+    # Override from Rule, so any RDATE or EXDATE values may be used without a time defined.
     #
     def on?(time, schedule)
       next_time(time, schedule, time).to_i == time.to_i || whole_day? && same_day?(time)
     end
 
     def whole_day?
-      time.hour == 0 && time.min == 0 && time.sec == 0
+      @whole_day
     end
 
     def same_day?(other)


### PR DESCRIPTION
Howdy friends. I have been evaluating different options to enumerate occurrences between dates, given only an iCal file. I think ice_cube is great for it. However, I must support RDATE, and it seems this change is all I need to finally adopt ice_cube. I hope you find it useful, and it finds its way into the gem. Cheers.
