### PR TITLE
Travis: Update bundler before installing gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+before_install:
+  - gem update bundler
 script: "bundle exec rspec spec"
 notifications:
   email:


### PR DESCRIPTION
Some versions of bundler are affected by a bug that causes them to throw

    NoMethodError: undefined method `spec' for nil:NilClass

during installation of the yaml_db gem. This bug was fixed in bundler@a0c90cd, but several of
Travis's Ruby environments are based on older affected versions. To resolve, we force an update.