### PR TITLE
Remove deprecation warning

### DIFF
--- a/lib/ice_cube/parsers/hash_parser.rb
+++ b/lib/ice_cube/parsers/hash_parser.rb
@@ -25,7 +25,7 @@ module IceCube
     def normalize_keys(hash)
       data = IceCube::FlexibleHash.new(hash.dup)
 
-      if (start_date = data.delete(:start_date))
+      if (start_date = data.delete(:start_date) && data[:start_time].blank?)
         warn "IceCube: :start_date is deprecated, please use :start_time at: #{ caller[0] }"
         data[:start_time] = start_date
       end


### PR DESCRIPTION
We don't want to be warn if the `start_date` key is only present for retrocompatibility purpose.