### PR TITLE
Fix day_of_year

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+before_install:
+  - gem update bundler
 script: "bundle exec rspec spec"
 notifications:
   email:

--- a/lib/ice_cube/validations/day_of_year.rb
+++ b/lib/ice_cube/validations/day_of_year.rb
@@ -31,7 +31,7 @@ module IceCube
 
       def validate(step_time, schedule)
         days_in_year = TimeUtil.days_in_year(step_time)
-        yday = day < 0 ? day + days_in_year : day
+        yday = day < 0 ? day + days_in_year + 1 : day
         offset = yday - step_time.yday
         offset >= 0 ? offset : offset + days_in_year
       end

--- a/spec/examples/hourly_rule_spec.rb
+++ b/spec/examples/hourly_rule_spec.rb
@@ -42,10 +42,10 @@ module IceCube
         schedule = Schedule.new(t0 = Time.local(2013, 11, 3, 0, 0, 0))
         schedule.add_recurrence_rule Rule.hourly
         schedule.first(4).should == [
-          Time.local(2013, 11, 3, 0, 0, 0),             # -0700
-          Time.local(2013, 11, 3, 1, 0, 0) - ONE_HOUR,  # -0700
-          Time.local(2013, 11, 3, 1, 0, 0),             # -0800
-          Time.local(2013, 11, 3, 2, 0, 0),             # -0800
+          Time.new(2013, 11, 3, 0, 0, 0, '-07:00'),
+          Time.new(2013, 11, 3, 1, 0, 0, '-07:00'),
+          Time.new(2013, 11, 3, 1, 0, 0, '-08:00'),
+          Time.new(2013, 11, 3, 2, 0, 0, '-08:00')
         ]
       end
 

--- a/spec/examples/yearly_rule_spec.rb
+++ b/spec/examples/yearly_rule_spec.rb
@@ -66,19 +66,19 @@ describe IceCube::YearlyRule do
     schedule.occurrences(Time.utc(2010, 12, 31)).size.should == 3
   end
 
-  it 'should produce the correct number of days for @interval = 1 when you specify days' do
+  it 'should produce the correct days for @interval = 1 when you specify days' do
     start_time = Time.utc(2010, 1, 1)
     schedule = IceCube::Schedule.new(start_time)
     schedule.add_recurrence_rule IceCube::Rule.yearly.day_of_year(155, 200)
     #check assumption
-    schedule.occurrences(Time.utc(2010, 12, 31)).size.should == 2
+    schedule.occurrences(Time.utc(2010, 12, 31)).should match_array [Time.utc(2010, 6, 4), Time.utc(2010, 7, 19)]
   end
 
-  it 'should produce the correct number of days for @interval = 1 when you specify negative days' do
+  it 'should produce the correct days for @interval = 1 when you specify negative days' do
     schedule = IceCube::Schedule.new(Time.utc(2010, 1, 1))
     schedule.add_recurrence_rule IceCube::Rule.yearly.day_of_year(100, -1)
     #check assumption
-    schedule.occurrences(Time.utc(2010, 12, 31)).size.should == 2
+    schedule.occurrences(Time.utc(2010, 12, 31)).should match_array [Time.utc(2010, 4, 10), Time.utc(2010, 12, 31)]
   end
 
 end


### PR DESCRIPTION
Looks like a simple fix - i.e. `day_of_year(-1)` should refer to day 365 (in a non-leap year), but as written it'll result in 364 (-1 + 365, on line 34). This should fix #277.
