### PR TITLE
Rules can override schedule's duration

### DIFF
--- a/lib/ice_cube.rb
+++ b/lib/ice_cube.rb
@@ -43,6 +43,7 @@ module IceCube
 
     autoload :Count, 'ice_cube/validations/count'
     autoload :Until, 'ice_cube/validations/until'
+    autoload :OverrideDuration, 'ice_cube/validations/override_duration'
 
     autoload :SecondlyInterval, 'ice_cube/validations/secondly_interval'
     autoload :MinutelyInterval, 'ice_cube/validations/minutely_interval'

--- a/lib/ice_cube/rule.rb
+++ b/lib/ice_cube/rule.rb
@@ -11,6 +11,11 @@ module IceCube
       until_time || occurrence_count
     end
 
+    # Does this rule override the schedule's duration?
+    def overrides_duration?
+      !duration.nil?
+    end
+
     def ==(rule)
       if rule.is_a? Rule
         hash = to_hash

--- a/lib/ice_cube/single_occurrence_rule.rb
+++ b/lib/ice_cube/single_occurrence_rule.rb
@@ -13,6 +13,11 @@ module IceCube
       true
     end
 
+    # Never overrides duration
+    def duration
+      nil
+    end
+
     def next_time(t, schedule, closing_time)
       unless closing_time && closing_time < t
         time if time.to_i >= t.to_i

--- a/lib/ice_cube/validated_rule.rb
+++ b/lib/ice_cube/validated_rule.rb
@@ -15,6 +15,7 @@ module IceCube
 
     include Validations::Count
     include Validations::Until
+    include Validations::OverrideDuration
 
     # Validations ordered for efficiency in sequence of:
     # * descending intervals
@@ -22,12 +23,13 @@ module IceCube
     # * base values by cardinality (n = 60, 60, 31, 24, 12, 7)
     # * locks by cardinality (n = 365, 60, 60, 31, 24, 12, 7)
     # * interval multiplier
+    # * duration
     VALIDATION_ORDER = [
       :year, :month, :day, :wday, :hour, :min, :sec, :count, :until,
       :base_sec, :base_min, :base_day, :base_hour, :base_month, :base_wday,
       :day_of_year, :second_of_minute, :minute_of_hour, :day_of_month,
       :hour_of_day, :month_of_year, :day_of_week,
-      :interval
+      :interval, :duration
     ]
 
     attr_reader :validations

--- a/lib/ice_cube/validations/override_duration.rb
+++ b/lib/ice_cube/validations/override_duration.rb
@@ -1,0 +1,53 @@
+module IceCube
+
+  module Validations::OverrideDuration
+
+    # Value reader for duration
+    def duration
+      @duration
+    end
+
+    def override_duration(duration)
+      @duration = duration
+      replace_validations_for(:duration, duration.nil? ? nil : [Validation.new(duration)])
+      self
+    end
+
+    class Validation
+
+      attr_reader :duration
+
+      def initialize(duration)
+        @duration = duration
+      end
+
+      def type
+        :duration
+      end
+
+      def dst_adjust?
+        false
+      end
+
+      # Always valid
+      def validate(step_time, schedule)
+      end
+
+      # Do nothing, duration does not affect output string
+      def build_s(builder)
+      end
+
+      def build_hash(builder)
+        builder[:duration] = duration
+      end
+
+      # Do nothing.Do not export DURATION to ical beacuse it would conflict
+      # with DTEND property of schedule (if any)
+      def build_ical(builder)
+      end
+
+    end
+
+  end
+
+end

--- a/spec/examples/recur_spec.rb
+++ b/spec/examples/recur_spec.rb
@@ -76,6 +76,44 @@ describe :occurring_between? do
     schedule.occurring_between?(start_time - 2, start_time - 1).should be_false
   end
 
+  describe "with a rule overriding schedule's duration" do
+    let(:start_time) { Time.local(2012, 7, 7, 7) }
+    let(:end_time)   { start_time + 30 }
+
+    let(:schedule) do
+      IceCube::Schedule.new(start_time, :duration => 1).tap do |schedule|
+        schedule.rrule IceCube::Rule.daily.override_duration(30)
+      end
+    end
+
+    it 'should affirm an occurrence that spans the range exactly' do
+      schedule.occurring_between?(start_time, end_time).should be_true
+    end
+
+    it 'should affirm an occurrence entirely contained within the range' do
+      schedule.occurring_between?(start_time + 1, end_time - 1).should be_true
+    end
+
+    it 'should affirm an occurrence spanning across the start of the range' do
+      schedule.occurring_between?(start_time - 1, start_time + 1).should be_true
+    end
+
+    it 'should affirm an occurrence spanning across the end of the range' do
+      schedule.occurring_between?(end_time - 1, end_time + 1).should be_true
+    end
+
+    it 'should affirm an occurrence spanning across the range entirely' do
+      schedule.occurring_between?(start_time - 1, end_time + 1).should be_true
+    end
+
+    it 'should deny an occurrence before the range' do
+      schedule.occurring_between?(end_time + 1, end_time + 2).should be_false
+    end
+
+    it 'should deny an occurrence after the range' do
+      schedule.occurring_between?(start_time - 2, start_time - 1).should be_false
+    end
+  end
 end
 
 describe :next_occurrence do
@@ -114,7 +152,6 @@ describe :next_occurrence do
     schedule.add_recurrence_rule Rule.hourly
     schedule.next_occurrence(schedule.start_time).should == schedule.start_time + 30 * ONE_MINUTE
   end
-
 end
 
 describe :next_occurrences do
@@ -170,5 +207,4 @@ describe :next_occurrences do
     schedule.rrule Rule.daily
     schedule.next_occurrences(5).should == schedule.next_occurrences(5)
   end
-
 end

--- a/spec/examples/schedule_spec.rb
+++ b/spec/examples/schedule_spec.rb
@@ -42,6 +42,13 @@ describe IceCube::Schedule do
       expect( next_hour ).to eq Time.utc(2014, 1, 2, 00, 34 , 56)
     end
 
+    it "should give precedence to rule duration and return an occurrence with that duration" do
+      schedule = IceCube::Schedule.new(Time.now, :duration => IceCube::ONE_HOUR * 4) do |s|
+        s.add_recurrence_rule IceCube::Rule.daily.override_duration(IceCube::ONE_HOUR * 2)
+      end
+      next_occurrence = schedule.next_occurrence(Time.now)
+      next_occurrence.duration.should == IceCube::ONE_HOUR * 2
+    end
   end
 
   describe :duration do
@@ -61,6 +68,30 @@ describe IceCube::Schedule do
       schedule.duration.should == 600
     end
 
+    it 'should return schedule duration even though a rule duration exists' do
+      schedule = IceCube::Schedule.new(Time.now, :duration => IceCube::ONE_HOUR * 4) do |s|
+        s.add_recurrence_rule IceCube::Rule.daily.override_duration(ONE_HOUR)
+      end
+      schedule.duration.should == IceCube::ONE_HOUR * 4
+    end
+  end
+
+  describe :max_duration do
+    it 'should get the maximum duration between the schedule and all the recurrence/exception rules in schedule' do
+      start = Time.now
+      schedule = IceCube::Schedule.new(start)
+      schedule.max_duration.should == 0
+      schedule.duration = 100
+      schedule.max_duration.should == 100
+      schedule.add_recurrence_rule IceCube::Rule.daily
+      schedule.max_duration.should == 100
+      schedule.add_recurrence_rule IceCube::Rule.daily(2).override_duration(50)
+      schedule.max_duration.should == 100
+      schedule.add_recurrence_rule IceCube::Rule.daily(3).override_duration(200)
+      schedule.max_duration.should == 200
+      schedule.add_exception_rule IceCube::Rule.daily(4).override_duration(300)
+      schedule.max_duration.should == 300
+    end
   end
 
   describe :occurring_at? do
@@ -75,6 +106,24 @@ describe IceCube::Schedule do
       expect( schedule.occurring_at?(Date.new(2014, 1, 2)) ).to eq false
     end
 
+    it "should give precedence to rule duration" do
+      schedule = IceCube::Schedule.new do |s|
+        s.start_time = Time.utc(2014, 1, 1, 0, 0, 0)
+        s.duration = IceCube::ONE_HOUR
+        s.add_recurrence_rule IceCube::Rule.daily
+      end
+      schedule2 = IceCube::Schedule.new do |s|
+        s.start_time = Time.utc(2014, 1, 1, 0, 0, 0)
+        s.duration = IceCube::ONE_HOUR
+        s.add_recurrence_rule IceCube::Rule.daily.override_duration(IceCube::ONE_HOUR * 2)
+      end
+      expect( schedule.occurring_at?(Time.utc(2014, 1, 1, 0, 30, 0)) ).to eq true
+      expect( schedule.occurring_at?(Time.utc(2014, 1, 1, 1, 30, 0)) ).to eq false
+
+      expect( schedule2.occurring_at?(Time.utc(2014, 1, 1, 0, 30, 0)) ).to eq true
+      expect( schedule2.occurring_at?(Time.utc(2014, 1, 1, 1, 30, 0)) ).to eq true
+      expect( schedule2.occurring_at?(Time.utc(2014, 1, 1, 2, 30, 0)) ).to eq false
+    end
   end
 
   describe :recurrence_times do
@@ -282,6 +331,27 @@ describe IceCube::Schedule do
       conflict.should be_false
     end
 
+    it 'should give precedence to rule duration for checking conflicts, negative case' do
+      start_time = Time.now
+      start_time2 = Time.now + 2 * IceCube::ONE_HOUR
+      schedule1 = IceCube::Schedule.new(start_time, :duration => IceCube::ONE_HOUR * 3)
+      schedule1.rrule IceCube::Rule.daily.override_duration(IceCube::ONE_HOUR)
+      schedule2 = IceCube::Schedule.new(start_time2, :duration => IceCube::ONE_HOUR)
+      schedule2.rrule IceCube::Rule.daily
+      conflict = schedule1.conflicts_with?(schedule2, start_time + IceCube::ONE_WEEK)
+      conflict.should be_false
+    end
+
+    it 'should give precedence to rule duration for checking conflicts, positive case' do
+      start_time = Time.now
+      start_time2 = Time.now + 2 * IceCube::ONE_HOUR
+      schedule1 = IceCube::Schedule.new(start_time, :duration => IceCube::ONE_HOUR)
+      schedule1.rrule IceCube::Rule.daily.override_duration(IceCube::ONE_HOUR * 3)
+      schedule2 = IceCube::Schedule.new(start_time2, :duration => IceCube::ONE_HOUR)
+      schedule2.rrule IceCube::Rule.daily
+      conflict = schedule1.conflicts_with?(schedule2, start_time + IceCube::ONE_WEEK)
+      conflict.should be_true
+    end
   end
 
   describe :each do
@@ -312,7 +382,6 @@ describe IceCube::Schedule do
       schedule.each_occurrence { |t| answers << t }
       answers.should == [t0, t1]
     end
-
   end
 
   describe :all_occurrences_enumerator do
@@ -484,7 +553,7 @@ describe IceCube::Schedule do
       long_event = schedule.remaining_occurrences_enumerator(t0 + IceCube::ONE_DAY, :spans => true).take(1)
       long_event.should == [t0]
     end
-    
+
     it 'should find occurrences between including previous one with duration spanning start' do
       t0 = Time.utc(2015, 10, 1, 10, 00)
       schedule = IceCube::Schedule.new(t0, :duration => IceCube::ONE_HOUR)
@@ -505,7 +574,7 @@ describe IceCube::Schedule do
       schedule = IceCube::Schedule.new(t0, :duration => IceCube::ONE_HOUR)
       schedule.occurs_between?(t0 + IceCube::ONE_HOUR, t0 + 2 * IceCube::ONE_HOUR, :spans => true).should be_false
     end
-    
+
     it 'should quickly fetch a future time from a recurring schedule' do
       t0 = Time.utc(2000, 10, 1, 00, 00)
       t1 = Time.utc(2015, 10, 1, 12, 00)
@@ -518,7 +587,7 @@ describe IceCube::Schedule do
       timing.should < 0.1
       occ.should == [t1]
     end
-    
+
     it 'should not include occurrence ending on start time' do
       t0 = Time.utc(2015, 10, 1, 10, 00)
       schedule = IceCube::Schedule.new(t0, :duration => IceCube::ONE_HOUR / 2)
@@ -527,6 +596,21 @@ describe IceCube::Schedule do
       third_occ.should == t0 + IceCube::ONE_HOUR
     end
 
+    it 'should give precedence to rule duration, negative case' do
+      t0 = Time.utc(2014, 1, 1, 0, 0, 0)
+      schedule = IceCube::Schedule.new(t0, :duration => IceCube::ONE_HOUR * 2)
+      schedule.add_recurrence_rule IceCube::Rule.daily.count(2).override_duration(IceCube::ONE_HOUR / 2)
+      occs = schedule.next_occurrences(10, t0 + IceCube::ONE_HOUR, :spans => true)
+      occs.should == [t0 + IceCube::ONE_DAY]
+    end
+
+    it 'should give precedence to rule duration, positive case' do
+      t0 = Time.utc(2014, 1, 1, 0, 0, 0)
+      schedule = IceCube::Schedule.new(t0, :duration => IceCube::ONE_HOUR / 2)
+      schedule.add_recurrence_rule IceCube::Rule.daily.count(2).override_duration(IceCube::ONE_HOUR * 2)
+      occs = schedule.next_occurrences(10, t0 + IceCube::ONE_HOUR, :spans => true)
+      occs.should == [t0, t0 + IceCube::ONE_DAY]
+    end
   end
 
   describe :previous_occurrence do

--- a/spec/examples/validated_rule_spec.rb
+++ b/spec/examples/validated_rule_spec.rb
@@ -45,7 +45,6 @@ describe IceCube, "::ValidatedRule" do
           rule.next_time(first + 1.hour + 1.second, schedule, nil).to_s.should_not == first.to_s
         end
       end
-
     end
 
     it 'should match times with usec' do
@@ -56,4 +55,48 @@ describe IceCube, "::ValidatedRule" do
       rule.next_time(first_time + 1, schedule, nil).should == first_time + 1
     end
   end
+
+  describe "duration validation" do
+    let(:rule) { IceCube::Rule.monthly }
+
+    it "should respond to :override_duration" do
+      rule.respond_to?(:override_duration).should == true
+    end
+
+    describe "#duration" do
+      it "should return nil if if no duration validation set" do
+        rule.duration.should == nil
+      end
+
+      it "should return the duration set with validation" do
+        rule.override_duration(IceCube::ONE_DAY).duration.should == IceCube::ONE_DAY
+      end
+    end
+
+    describe "#overrides_duration?" do
+      it "should return true with duration validation" do
+        rule.override_duration(IceCube::ONE_DAY).overrides_duration?.should == true
+      end
+
+      it "should return false if no duration validation set" do
+        rule.overrides_duration?.should == false
+      end
+    end
+
+    it "should not affect string builder" do
+      rule.to_s.should == rule.override_duration(IceCube::ONE_DAY).to_s
+    end
+
+    it "should export :duration to hash" do
+      rule.to_hash.should_not have_key :duration
+      rule.override_duration(IceCube::ONE_DAY).to_hash[:duration].should == IceCube::ONE_DAY
+    end
+
+    it "should not export duration to ICAL" do
+      rule.to_ical.should == rule.override_duration(IceCube::ONE_DAY).to_ical
+    end
+  end
+
+
+
 end


### PR DESCRIPTION
fixes #322.

I added the possibility to override the duration of a schedule in a rule. This is made with a new validator (OverrideDuration) to keep the syntax as easy as `Rule.daily.override_duration(4.hours)`

I changed all the methods that make use of `schedule.duration` to give precedence to `rule.duration`

**About builders**

* `StringBuilder` was not affected because I see that `schedule.to_s` doesn't output schedule's duration either
* `HashBuilder` is used to store `:duration` in case the rule has a duration.
* `ICalBuilder` was not changed because adding 'DURATION' would bring to conflicts with schedule's duration or even with other rules. Maybe it's not an optimal solution, but I didn't see in the code a handling of the iCal property 'DURATION', so I didn't want to break anything.

I tested with these ruby versions: 1.9.3-p551, 2.0.0-p643, ruby-2.1.5, ruby-2.2.2, ruby-2.3.0 1.9.3

I didn't change or remove any old test and I just added new tests to fully cover all my changes. All tests pass in my machine.

Hope this may help