### PR TITLE
Wday weekly schedule problem

### DIFF
--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -509,17 +509,22 @@ module IceCube
     # of week N-1, the first jump would go to end of week N and miss any
     # earlier validations in the week). This realigns the opening time to
     # the start of the interval's correct period (e.g. move to start of week N)
-    # TODO: check if this is needed for validations other than `:wday`
     #
+    # Should only apply to WeeklyRule, use wkst as place to go back to
     def realign(opening_time)
       time = TimeUtil::TimeWrapper.new(opening_time)
       recurrence_rules.each do |rule|
+
+# fix from here: https://github.com/seejohnrun/ice_cube/pull/284/commits/e6305efc87d5f8b555c23e78ededaea3b89e68ea
         wday_validations = rule.other_interval_validations.select { |v| v.type == :wday } or next
         interval = rule.base_interval_validation.validate(opening_time, self).to_i
         offset = wday_validations
           .map { |v| v.validate(opening_time, self).to_i }
           .reduce(0) { |least, i| i > 0 && i <= interval && (i < least || least == 0) ? i : least }
         time.add(rule.base_interval_type, 7 - time.to_time.wday) if offset > 0
+
+#        next unless rule.respond_to?(:week_start)
+#        time.add(rule.base_interval_type, TimeUtil.sym_to_wday(rule.week_start) - time.to_time.wday)
       end
       time.to_time
     end

--- a/lib/ice_cube/validations/weekly_interval.rb
+++ b/lib/ice_cube/validations/weekly_interval.rb
@@ -40,6 +40,9 @@ module IceCube
         days = (d1 - TimeUtil.normalize_wday(d1.wday, week_start)) -
                (d0 - TimeUtil.normalize_wday(d0.wday, week_start))
         offset = ((days.to_i / 7) % interval).nonzero?
+        #on schedules with start_week on Monday, the offset calculated
+        #on Sunday is inaccurate due to using wday method that returns 0 for Sunday(instead of 6 as the last day of week)
+#        offset = offset + 1 if offset && week_start == :monday && d1.wday == 0
         (interval - offset) * 7 if offset
       end
 

--- a/lib/ice_cube/validations/weekly_interval.rb
+++ b/lib/ice_cube/validations/weekly_interval.rb
@@ -40,9 +40,6 @@ module IceCube
         days = (d1 - TimeUtil.normalize_wday(d1.wday, week_start)) -
                (d0 - TimeUtil.normalize_wday(d0.wday, week_start))
         offset = ((days.to_i / 7) % interval).nonzero?
-        #on schedules with start_week on Monday, the offset calculated
-        #on Sunday is inaccurate due to using wday method that returns 0 for Sunday(instead of 6 as the last day of week)
-#        offset = offset + 1 if offset && week_start == :monday && d1.wday == 0
         (interval - offset) * 7 if offset
       end
 

--- a/spec/examples/ice_cube_spec.rb
+++ b/spec/examples/ice_cube_spec.rb
@@ -213,8 +213,8 @@ describe IceCube::Schedule do
     dates = schedule.all_occurrences
     dates.each { |d| d.utc?.should == false }
     dates.should == [Time.zone.local(2010, 11, 6, 5, 0, 0),
-      Time.zone.local(2010, 11, 7, 5, 0, 0), Time.zone.local(2010, 11, 8, 5, 0, 0),
-      Time.zone.local(2010, 11, 9, 5, 0, 0)]
+                     Time.zone.local(2010, 11, 7, 5, 0, 0), Time.zone.local(2010, 11, 8, 5, 0, 0),
+                     Time.zone.local(2010, 11, 9, 5, 0, 0)]
   end
 
   # here we purposely put a local time that is before the range ends, to
@@ -228,8 +228,8 @@ describe IceCube::Schedule do
     dates = schedule.all_occurrences
     dates.each { |d| d.utc?.should == true }
     dates.should == [Time.utc(2010, 11, 6, 5, 0, 0),
-      Time.utc(2010, 11, 7, 5, 0, 0), Time.utc(2010, 11, 8, 5, 0, 0),
-      Time.utc(2010, 11, 9, 5, 0, 0)]
+                     Time.utc(2010, 11, 7, 5, 0, 0), Time.utc(2010, 11, 8, 5, 0, 0),
+                     Time.utc(2010, 11, 9, 5, 0, 0)]
   end
 
   it 'works with a monthly rule iterating on UTC' do
@@ -318,22 +318,50 @@ describe IceCube::Schedule do
 
   describe "using occurs_between with a biweekly schedule" do
     [[0, 1, 2], [0, 6, 1], [5, 1, 6], [6, 5, 7]].each do |wday, offset, lead|
-      start_week    = Time.utc(2014, 1, 5)
-      expected_week =  start_week + 2.weeks
-      offset_wday   = (wday + offset) % 7
+      start_week = Time.utc(2014, 1, 5)
+      expected_week = start_week + 2.weeks
+      offset_wday = (wday + offset) % 7
 
       context "starting on weekday #{wday} selecting weekday #{offset} with a #{lead} day advance window" do
-        let(:biweekly)      { Rule.weekly(2).day(0, 1, 2, 3, 4, 5, 6) }
-        let(:schedule)      { Schedule.new(start_week + wday.days) { |s| s.rrule biweekly } }
+        let(:biweekly) { IceCube::Rule.weekly(2).day(0, 1, 2, 3, 4, 5, 6) }
+        let(:schedule) { IceCube::Schedule.new(start_week + wday.days) { |s| s.rrule biweekly } }
         let(:expected_date) { expected_week + offset_wday.days }
-        let(:range)         { [expected_date - lead.days, expected_date] }
+        let(:range) { [expected_date - lead.days, expected_date] }
 
         it "should include weekday #{offset_wday} of the expected week" do
           expect(schedule.occurrences_between(range.first, range.last)).to include expected_date
         end
       end
-
     end
+  end
+
+  describe "using occurs_between with a weekly schedule" do
+    [[6, 5, 7]].each do |wday, offset, lead|
+      start_week = Time.utc(2014, 1, 5)
+      expected_week = start_week + 1.weeks
+      offset_wday = (wday + offset) % 7
+
+      context "starting on weekday #{wday} selecting weekday #{offset} with a #{lead} day advance window" do
+        let(:weekly) { IceCube::Rule.weekly(1).day(0, 1, 2, 3, 4, 5, 6) }
+        let(:schedule) { IceCube::Schedule.new(start_week + wday.days) { |s| s.rrule weekly } }
+        let(:expected_date) { expected_week + offset_wday.days }
+        let(:range) { [expected_date - lead.days, expected_date] }
+
+        it "should include weekday #{offset_wday} of the expected week" do
+          expect(schedule.occurrences_between(range.first, range.last)).to include expected_date
+          expect(schedule.occurrences_between(range.first, range.last).first).to eq(start_week + wday.days)
+        end
+      end
+    end
+  end
+
+  it 'should produce correct days for bi-weekly interval, starting on a non-sunday' do
+    schedule = IceCube::Schedule.new(t0 = Time.local(2015, 3, 3))
+    schedule.add_recurrence_rule IceCube::Rule.weekly(2, :monday).day(:tuesday)
+    #check assumption
+    range_start = Time.local(2015, 3, 15)
+    times = schedule.occurrences_between(range_start, range_start + IceCube::ONE_WEEK)
+    times.first.should == Time.local(2015, 3, 17)
   end
 
   it 'should be able to tell us when there is at least one occurrence between two dates' do

--- a/spec/examples/weekly_rule_spec.rb
+++ b/spec/examples/weekly_rule_spec.rb
@@ -211,6 +211,17 @@ module IceCube
       end
     end
 
+    it 'should include first occurrence on biweekly sundays when monday is the week start' do
+      schedule = Schedule.new(t0 = Time.utc(2012, 2, 12)) # this was a sunday
+      schedule.add_recurrence_rule Rule.weekly(2, :monday).day(:sunday)
+      expect(schedule.occurrences_between(t0 - ONE_WEEK, t0 + 3 * (ONE_WEEK))).to eq(
+        [
+          Time.utc(2012, 2, 12),
+          Time.utc(2012, 2, 26),
+        ]
+      )
+    end
+
     it 'should start weekly rules on sunday by default' do
       schedule = Schedule.new(t0 = Time.local(2012,2,7))
       schedule.add_recurrence_rule Rule.weekly(2).day(:tuesday, :sunday)

--- a/spec/examples/weekly_rule_spec.rb
+++ b/spec/examples/weekly_rule_spec.rb
@@ -147,6 +147,70 @@ module IceCube
       ]
     end
 
+    it 'should produce correct next occurrences on biweekly tuesdays when monday is the week start' do
+      schedule = Schedule.new(t0 = Time.utc(2012, 2, 7)) # this was a tuesday
+      schedule.add_recurrence_rule Rule.weekly(2, :monday).day(:tuesday)
+      occurrences = 17.times.map do |n|
+        now = t0 + (n * ONE_DAY)
+        "#{now.to_date.iso8601} (#{now.wday}) => #{schedule.next_occurrences(1, now)[0].to_date.iso8601}"
+      end
+      expected = (<<-TXT
+        2012-02-07 (2) => 2012-02-21
+        2012-02-08 (3) => 2012-02-21
+        2012-02-09 (4) => 2012-02-21
+        2012-02-10 (5) => 2012-02-21
+        2012-02-11 (6) => 2012-02-21
+        2012-02-12 (0) => 2012-02-21
+        2012-02-13 (1) => 2012-02-21
+        2012-02-14 (2) => 2012-02-21
+        2012-02-15 (3) => 2012-02-21
+        2012-02-16 (4) => 2012-02-21
+        2012-02-17 (5) => 2012-02-21
+        2012-02-18 (6) => 2012-02-21
+        2012-02-19 (0) => 2012-02-21
+        2012-02-20 (1) => 2012-02-21
+        2012-02-21 (2) => 2012-03-06
+        2012-02-22 (3) => 2012-03-06
+        2012-02-23 (4) => 2012-03-06
+        TXT
+      ).split("\n").map(&:strip)
+      expected.each_with_index do |time, i|
+        expect(occurrences[i]).to eq(time)
+      end
+    end
+
+    it 'should produce correct next occurrences on biweekly sundays when monday is the week start' do
+      schedule = Schedule.new(t0 = Time.utc(2012, 2, 12)) # this was a sunday
+      schedule.add_recurrence_rule Rule.weekly(2, :monday).day(:sunday)
+      occurrences = 17.times.map do |n|
+        now = t0 + (n * ONE_DAY)
+        "#{now.to_date.iso8601} (#{now.wday}) => #{schedule.next_occurrences(1, now)[0].to_date.iso8601}"
+      end
+      expected = (<<-TXT
+        2012-02-12 (0) => 2012-02-26
+        2012-02-13 (1) => 2012-02-26
+        2012-02-14 (2) => 2012-02-26
+        2012-02-15 (3) => 2012-02-26
+        2012-02-16 (4) => 2012-02-26
+        2012-02-17 (5) => 2012-02-26
+        2012-02-18 (6) => 2012-02-26
+        2012-02-19 (0) => 2012-02-26
+        2012-02-20 (1) => 2012-02-26
+        2012-02-21 (2) => 2012-02-26
+        2012-02-22 (3) => 2012-02-26
+        2012-02-23 (4) => 2012-02-26
+        2012-02-24 (5) => 2012-02-26
+        2012-02-25 (6) => 2012-02-26
+        2012-02-26 (0) => 2012-03-11
+        2012-02-27 (1) => 2012-03-11
+        2012-02-28 (2) => 2012-03-11
+        TXT
+      ).split("\n").map(&:strip)
+      expected.each_with_index do |time, i|
+        expect(occurrences[i]).to eq(time)
+      end
+    end
+
     it 'should start weekly rules on sunday by default' do
       schedule = Schedule.new(t0 = Time.local(2012,2,7))
       schedule.add_recurrence_rule Rule.weekly(2).day(:tuesday, :sunday)


### PR DESCRIPTION
Hello!
This fixes a bug that occurs when using weekly schedules and having monday as the week start. On some days, the bug would cause occurrences to be missed.
The fix is simply using the wday normalizing method that is being used everywhere else, as far as I can see it has been overlooked. Also, lots of collected tests are added.