### PR TITLE
Validate rule types while parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Current
+
+* Validate rules (and raise ArgumentError) on invalid `from_hash`
+* Make the iCal parser use the `from_hash` implementation under the hood
+
 ## 0.14.0 / 2016-02-23
 
 * Added span option for occurrence methods

--- a/lib/ice_cube/rule.rb
+++ b/lib/ice_cube/rule.rb
@@ -4,6 +4,11 @@ module IceCube
 
   class Rule
 
+    INTERVAL_TYPES = [
+      :secondly, :minutely, :hourly,
+      :daily, :weekly, :monthly, :yearly
+    ]
+
     attr_reader :uses
 
     # Is this a terminating schedule?
@@ -46,21 +51,6 @@ module IceCube
       raise MethodNotImplemented, "Expected to be overridden by subclasses"
     end
 
-    # Convert from a hash and create a rule
-    def self.from_hash(original_hash)
-      hash = IceCube::FlexibleHash.new original_hash
-      return nil unless match = hash[:rule_type].match(/\:\:(.+?)Rule/)
-      rule = IceCube::Rule.send(match[1].downcase.to_sym, hash[:interval] || 1)
-      rule.interval(hash[:interval] || 1, TimeUtil.wday_to_sym(hash[:week_start] || 0)) if match[1] == "Weekly"
-      rule.until(TimeUtil.deserialize_time(hash[:until])) if hash[:until]
-      rule.count(hash[:count]) if hash[:count]
-      hash[:validations] && hash[:validations].each do |key, value|
-        key = key.to_sym unless key.is_a?(Symbol)
-        value.is_a?(Array) ? rule.send(key, *value) : rule.send(key, value)
-      end
-      rule
-    end
-
     # Reset the uses on the rule to 0
     def reset
       @uses = 0
@@ -76,6 +66,36 @@ module IceCube
     # Whether this rule requires a full run
     def full_required?
       !@count.nil?
+    end
+
+    class << self
+
+      # Convert from a hash and create a rule
+      def from_hash(original_hash)
+        hash = IceCube::FlexibleHash.new original_hash
+        return nil unless match = hash[:rule_type].match(/\:\:(.+?)Rule/)
+
+        interval_type = match[1].downcase.to_sym
+        raise ArgumentError, "Invalid rule frequency type: #{match[1]}" unless INTERVAL_TYPES.include?(interval_type)
+
+        rule = IceCube::Rule.send(interval_type, hash[:interval] || 1)
+        rule.interval(hash[:interval] || 1, TimeUtil.wday_to_sym(hash[:week_start] || 0)) if match[1] == "Weekly"
+        rule.until(TimeUtil.deserialize_time(hash[:until])) if hash[:until]
+        rule.count(hash[:count]) if hash[:count]
+        hash[:validations] && hash[:validations].each do |name, args|
+          apply_validation(rule, name, args)
+        end
+        rule
+      end
+
+      private
+
+      def apply_validation(rule, name, args)
+        name = name.to_sym
+        raise ArgumentError, "Invalid rule validation type: #{name}" unless ValidatedRule::VALIDATION_ORDER.include?(name)
+        args.is_a?(Array) ? rule.send(name, *args) : rule.send(name, args)
+      end
+
     end
 
     # Convenience methods for creating Rules

--- a/spec/examples/from_ical_spec.rb
+++ b/spec/examples/from_ical_spec.rb
@@ -367,6 +367,16 @@ module IceCube
         schedule = IceCube::Schedule.from_ical ical_string_with_multiple_exdates
         schedule.exception_times.count.should == 3
       end
+
+      it 'should raise ArgumentError when parsing an invalid rule type' do
+        str = 'FREQ=FAKE'
+        lambda { Rule.from_ical(str) }.should raise_error(ArgumentError, 'Invalid rule frequency type: Fake')
+      end
+
+      it 'should raise ArgumentError when parsing an invalid validation type' do
+        str = 'FREQ=DAILY;FAKE=23'
+        lambda { Rule.from_ical(str) }.should raise_error(ArgumentError, 'Invalid rule validation type: FAKE')
+      end
     end
 
     describe 'multiple rules' do

--- a/spec/examples/to_yaml_spec.rb
+++ b/spec/examples/to_yaml_spec.rb
@@ -293,5 +293,15 @@ module IceCube
       YAML.load(symbol_yaml).should == YAML.load(string_yaml)
     end
 
+    it 'should raise an ArgumentError when trying to deserialize an invalid rule type' do
+      data = {:rule_type => 'IceCube::FakeRule', :interval => 1}
+      lambda { Rule.from_hash(data) }.should raise_error(ArgumentError, 'Invalid rule frequency type: Fake')
+    end
+
+    it 'should raise an ArgumentError when trying to deserialize an invalid validation' do
+      data = {:validations => {:fake => []}, :rule_type => 'IceCube::DailyRule', :interval => 1}
+      lambda { Rule.from_hash(data) }.should raise_error(ArgumentError, 'Invalid rule validation type: fake')
+    end
+
   end
 end


### PR DESCRIPTION
Also modify `Rule#from_ical` to use `Rule#from_hash` for uniformity and
centralization of parsing logic.