### PR TITLE
Fix tests on older rubies

### DIFF
--- a/ice_cube.gemspec
+++ b/ice_cube.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec', '~> 2.12.0')
-  s.add_development_dependency('activesupport', '>= 3.0.0')
+  s.add_development_dependency('activesupport', ['>= 3.0.0', ('<5' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.2'))].compact)
   s.add_development_dependency('tzinfo')
   s.add_development_dependency('i18n')
 end


### PR DESCRIPTION
Don't try to bring in new activesupport on versions of Ruby that don't
support it