### PR TITLE
Fixing biweekly realign when used with spans option.

### DIFF
--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -413,7 +413,7 @@ module IceCube
       spans = options[:spans] == true && duration != 0
       Enumerator.new do |yielder|
         reset
-        t1 = full_required? ? start_time : realign((spans ? opening_time - duration : opening_time))
+        t1 = full_required? ? start_time : realign(opening_time) - (spans ? duration : 0)
         loop do
           break unless (t0 = next_time(t1, closing_time))
           break if closing_time && t0 > closing_time

--- a/spec/examples/weekly_rule_spec.rb
+++ b/spec/examples/weekly_rule_spec.rb
@@ -165,6 +165,16 @@ module IceCube
       ])
     end
 
+    it 'should find the next date on a biweekly sunday searching from a few days before the date' do
+      t0 = Time.utc(2017, 1, 15, 9, 0, 0)
+      t1 = Time.utc(2017, 1, 24)
+      t2 = t0 + (2 * ONE_WEEK)
+      schedule = Schedule.new(t0, :duration => IceCube::ONE_HOUR)
+      schedule.add_recurrence_rule Rule.weekly(2, :sunday).day(:sunday)
+      t3 = schedule.next_occurrence(t1, :spans => true)
+      expect(t3).to eq(t2)
+    end
+
     it 'should validate week_start input' do
       expect { Rule.weekly(2, :someday) }.to raise_error(ArgumentError)
     end


### PR DESCRIPTION
This PR fixes an edge case bug for the use of the spans option when the biweekly realign method comes into effect. The realign method was being called with the opening time with the duration shift, whereas it should always be using the pure opening time.

Thanks for all the work you've been doing on the gem recently! It's not gone unnoticed.