### PR TITLE
Fix first weekly occurrences with non-Sunday week start

### DIFF
--- a/lib/ice_cube/rule.rb
+++ b/lib/ice_cube/rule.rb
@@ -11,6 +11,9 @@ module IceCube
 
     attr_reader :uses
 
+    def reset
+    end
+
     # Is this a terminating schedule?
     def terminating?
       until_time || occurrence_count
@@ -49,11 +52,6 @@ module IceCube
 
     def to_hash
       raise MethodNotImplemented, "Expected to be overridden by subclasses"
-    end
-
-    # Reset the uses on the rule to 0
-    def reset
-      @uses = 0
     end
 
     def next_time(time, schedule, closing_time)

--- a/lib/ice_cube/rules/daily_rule.rb
+++ b/lib/ice_cube/rules/daily_rule.rb
@@ -4,7 +4,7 @@ module IceCube
 
     include Validations::DailyInterval
 
-    def initialize(interval = 1, week_start = :sunday)
+    def initialize(interval = 1)
       super
       interval(interval)
       schedule_lock(:hour, :min, :sec)

--- a/lib/ice_cube/rules/hourly_rule.rb
+++ b/lib/ice_cube/rules/hourly_rule.rb
@@ -4,7 +4,7 @@ module IceCube
 
     include Validations::HourlyInterval
 
-    def initialize(interval = 1, week_start = :sunday)
+    def initialize(interval = 1)
       super
       interval(interval)
       schedule_lock(:min, :sec)

--- a/lib/ice_cube/rules/minutely_rule.rb
+++ b/lib/ice_cube/rules/minutely_rule.rb
@@ -4,7 +4,7 @@ module IceCube
 
     include Validations::MinutelyInterval
 
-    def initialize(interval = 1, week_start = :sunday)
+    def initialize(interval = 1)
       super
       interval(interval)
       schedule_lock(:sec)

--- a/lib/ice_cube/rules/monthly_rule.rb
+++ b/lib/ice_cube/rules/monthly_rule.rb
@@ -4,7 +4,7 @@ module IceCube
 
     include Validations::MonthlyInterval
 
-    def initialize(interval = 1, week_start = :sunday)
+    def initialize(interval = 1)
       super
       interval(interval)
       schedule_lock(:day, :hour, :min, :sec)

--- a/lib/ice_cube/rules/secondly_rule.rb
+++ b/lib/ice_cube/rules/secondly_rule.rb
@@ -4,7 +4,7 @@ module IceCube
 
     include Validations::SecondlyInterval
 
-    def initialize(interval = 1, week_start = :sunday)
+    def initialize(interval = 1)
       super
       interval(interval)
       reset

--- a/lib/ice_cube/rules/weekly_rule.rb
+++ b/lib/ice_cube/rules/weekly_rule.rb
@@ -13,16 +13,28 @@ module IceCube
       reset
     end
 
+    # Calculate the effective start time for when the given start time is later
+    # in the week than one of the weekday validations, such that times could be
+    # missed by a 7-day jump using the weekly interval, or when selecting from a
+    # date that is misaligned from the schedule interval.
+    #
+    def realign(step_time, start_time)
+      time = TimeUtil::TimeWrapper.new(start_time)
+      offset = wday_offset(step_time, start_time)
+      time.add(:day, offset) if offset
+      time.to_time
+    end
+
     def wday_offset(step_time, start_time)
       wday_validations = other_interval_validations.select { |v| v.type == :wday }
       return if wday_validations.none?
 
+      days = (step_time - start_time).to_i / ONE_DAY
       interval = base_interval_validation.validate(step_time, start_time).to_i
-      offset = wday_validations
-        .map { |v| v.validate(step_time, start_time).to_i }
-        .reduce(0) { |least, i| i > 0 && i <= interval && (i < least || least == 0) ? i : least }
+      min_wday = TimeUtil.normalize_wday(wday_validations.min_by(&:day).day, week_start)
+      step_wday = TimeUtil.normalize_wday(step_time.wday, week_start)
 
-      7 - TimeUtil.normalize_wday(step_time.wday, week_start) if offset > 0
+      days + interval - step_wday + min_wday
     end
 
   end

--- a/lib/ice_cube/rules/weekly_rule.rb
+++ b/lib/ice_cube/rules/weekly_rule.rb
@@ -4,8 +4,10 @@ module IceCube
 
     include Validations::WeeklyInterval
 
+    attr_reader :week_start
+
     def initialize(interval = 1, week_start = :sunday)
-      super
+      super(interval)
       interval(interval, week_start)
       schedule_lock(:wday, :hour, :min, :sec)
       reset

--- a/lib/ice_cube/rules/weekly_rule.rb
+++ b/lib/ice_cube/rules/weekly_rule.rb
@@ -13,6 +13,18 @@ module IceCube
       reset
     end
 
+    def wday_offset(step_time, start_time)
+      wday_validations = other_interval_validations.select { |v| v.type == :wday }
+      return if wday_validations.none?
+
+      interval = base_interval_validation.validate(step_time, start_time).to_i
+      offset = wday_validations
+        .map { |v| v.validate(step_time, start_time).to_i }
+        .reduce(0) { |least, i| i > 0 && i <= interval && (i < least || least == 0) ? i : least }
+
+      7 - step_time.wday if offset > 0
+    end
+
   end
 
 end

--- a/lib/ice_cube/rules/weekly_rule.rb
+++ b/lib/ice_cube/rules/weekly_rule.rb
@@ -22,7 +22,7 @@ module IceCube
         .map { |v| v.validate(step_time, start_time).to_i }
         .reduce(0) { |least, i| i > 0 && i <= interval && (i < least || least == 0) ? i : least }
 
-      7 - step_time.wday if offset > 0
+      7 - TimeUtil.normalize_wday(step_time.wday, week_start) if offset > 0
     end
 
   end

--- a/lib/ice_cube/rules/yearly_rule.rb
+++ b/lib/ice_cube/rules/yearly_rule.rb
@@ -4,7 +4,7 @@ module IceCube
 
     include Validations::YearlyInterval
 
-    def initialize(interval = 1, week_start = :sunday)
+    def initialize(interval = 1)
       super
       interval(interval)
       schedule_lock(:month, :day, :hour, :min, :sec)

--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -509,17 +509,12 @@ module IceCube
     # of week N-1, the first jump would go to end of week N and miss any
     # earlier validations in the week). This realigns the opening time to
     # the start of the interval's correct period (e.g. move to start of week N)
-    # TODO: check if this is needed for validations other than `:wday`
     #
     def realign(opening_time)
       time = TimeUtil::TimeWrapper.new(opening_time)
       recurrence_rules.each do |rule|
-        wday_validations = rule.other_interval_validations.select { |v| v.type == :wday } or next
-        interval = rule.base_interval_validation.validate(opening_time, start_time).to_i
-        offset = wday_validations
-          .map { |v| v.validate(opening_time, start_time).to_i }
-          .reduce(0) { |least, i| i > 0 && i <= interval && (i < least || least == 0) ? i : least }
-        time.add(rule.base_interval_type, 7 - time.to_time.wday) if offset > 0
+        offset = rule.wday_offset(opening_time, start_time)
+        time.add(:day, offset) if offset
       end
       time.to_time
     end

--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -439,7 +439,7 @@ module IceCube
       loop do
         min_time = recurrence_rules_with_implicit_start_occurrence.reduce(nil) do |min_time, rule|
           begin
-            new_time = rule.next_time(time, self, min_time || closing_time)
+            new_time = rule.next_time(time, start_time, min_time || closing_time)
             [min_time, new_time].compact.min
           rescue StopIteration
             min_time
@@ -462,7 +462,7 @@ module IceCube
     # is excluded from the schedule
     def exception_time?(time)
       @all_exception_rules.any? do |rule|
-        rule.on?(time, self)
+        rule.on?(time, start_time)
       end
     end
 
@@ -515,9 +515,9 @@ module IceCube
       time = TimeUtil::TimeWrapper.new(opening_time)
       recurrence_rules.each do |rule|
         wday_validations = rule.other_interval_validations.select { |v| v.type == :wday } or next
-        interval = rule.base_interval_validation.validate(opening_time, self).to_i
+        interval = rule.base_interval_validation.validate(opening_time, start_time).to_i
         offset = wday_validations
-          .map { |v| v.validate(opening_time, self).to_i }
+          .map { |v| v.validate(opening_time, start_time).to_i }
           .reduce(0) { |least, i| i > 0 && i <= interval && (i < least || least == 0) ? i : least }
         time.add(rule.base_interval_type, 7 - time.to_time.wday) if offset > 0
       end

--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -413,7 +413,7 @@ module IceCube
       spans = options[:spans] == true && duration != 0
       Enumerator.new do |yielder|
         reset
-        t1 = full_required? ? start_time : realign(opening_time) - (spans ? duration : 0)
+        t1 = full_required? ? start_time : opening_time - (spans ? duration : 0)
         loop do
           break unless (t0 = next_time(t1, closing_time))
           break if closing_time && t0 > closing_time
@@ -500,23 +500,6 @@ module IceCube
       recurrence_rules.each do |rule|
         rule.skipped_for_dst
       end
-    end
-
-    # If any rule has validations for values within the period, (overriding the
-    # interval from start time, e.g.  `day[_of_week]`), and the opening time is
-    # offset from the interval multiplier such that it might miss the first
-    # correct occurrence (e.g. repeat is every N weeks, but selecting from end
-    # of week N-1, the first jump would go to end of week N and miss any
-    # earlier validations in the week). This realigns the opening time to
-    # the start of the interval's correct period (e.g. move to start of week N)
-    #
-    def realign(opening_time)
-      time = TimeUtil::TimeWrapper.new(opening_time)
-      recurrence_rules.each do |rule|
-        offset = rule.wday_offset(opening_time, start_time)
-        time.add(:day, offset) if offset
-      end
-      time.to_time
     end
 
   end

--- a/lib/ice_cube/single_occurrence_rule.rb
+++ b/lib/ice_cube/single_occurrence_rule.rb
@@ -13,7 +13,7 @@ module IceCube
       true
     end
 
-    def next_time(t, schedule, closing_time)
+    def next_time(t, _, closing_time)
       unless closing_time && closing_time < t
         time if time.to_i >= t.to_i
       end

--- a/lib/ice_cube/validated_rule.rb
+++ b/lib/ice_cube/validated_rule.rb
@@ -59,12 +59,16 @@ module IceCube
     # to the given start time
     def next_time(time, start_time, closing_time)
       @time = time
-      @start_time = start_time
+      @start_time ||= realign(time, start_time)
 
       return nil unless find_acceptable_time_before(closing_time)
 
       @uses += 1 if @time
       @time
+    end
+
+    def realign(opening_time, start_time)
+      start_time
     end
 
     def skipped_for_dst
@@ -73,9 +77,6 @@ module IceCube
 
     def dst_adjust?
       @validations[:interval].any? &:dst_adjust?
-    end
-
-    def wday_offset(step_time, start_time)
     end
 
     def to_s

--- a/lib/ice_cube/validated_rule.rb
+++ b/lib/ice_cube/validated_rule.rb
@@ -49,10 +49,10 @@ module IceCube
     end
 
     # Compute the next time after (or including) the specified time in respect
-    # to the given schedule
-    def next_time(time, schedule, closing_time)
+    # to the given start time
+    def next_time(time, start_time, closing_time)
       @time = time
-      @schedule = schedule
+      @start_time = start_time
 
       return nil unless find_acceptable_time_before(closing_time)
 
@@ -145,7 +145,7 @@ module IceCube
     #
     def validation_accepts_or_updates_time?(validations_for_type)
       res = validations_for_type.each_with_object([]) do |validation, offsets|
-        r = validation.validate(@time, @schedule)
+        r = validation.validate(@time, @start_time)
         return true if r.nil? || r == 0
         offsets << r
       end

--- a/lib/ice_cube/validated_rule.rb
+++ b/lib/ice_cube/validated_rule.rb
@@ -36,6 +36,13 @@ module IceCube
       @validations = Hash.new
     end
 
+    # Reset the uses on the rule to 0
+    def reset
+      @time = nil
+      @start_time = nil
+      @uses = 0
+    end
+
     def base_interval_validation
       @validations[:interval].first
     end

--- a/lib/ice_cube/validated_rule.rb
+++ b/lib/ice_cube/validated_rule.rb
@@ -32,7 +32,7 @@ module IceCube
 
     attr_reader :validations
 
-    def initialize(interval = 1, *)
+    def initialize(interval = 1)
       @validations = Hash.new
     end
 

--- a/lib/ice_cube/validated_rule.rb
+++ b/lib/ice_cube/validated_rule.rb
@@ -68,6 +68,9 @@ module IceCube
       @validations[:interval].any? &:dst_adjust?
     end
 
+    def wday_offset(step_time, start_time)
+    end
+
     def to_s
       builder = StringBuilder.new
       @validations.each do |name, validations|

--- a/lib/ice_cube/validations/count.rb
+++ b/lib/ice_cube/validations/count.rb
@@ -33,7 +33,7 @@ module IceCube
         false
       end
 
-      def validate(time, schedule)
+      def validate(time, start_time)
         raise CountExceeded if rule.uses && rule.uses >= count
       end
 

--- a/lib/ice_cube/validations/daily_interval.rb
+++ b/lib/ice_cube/validations/daily_interval.rb
@@ -26,8 +26,8 @@ module IceCube
         true
       end
 
-      def validate(step_time, schedule)
-        t0, t1 = schedule.start_time, step_time
+      def validate(step_time, start_time)
+        t0, t1 = start_time, step_time
         days = Date.new(t1.year, t1.month, t1.day) -
                Date.new(t0.year, t0.month, t0.day)
         offset = (days % interval).nonzero?

--- a/lib/ice_cube/validations/day_of_week.rb
+++ b/lib/ice_cube/validations/day_of_week.rb
@@ -30,7 +30,7 @@ module IceCube
         true
       end
 
-      def validate(step_time, schedule)
+      def validate(step_time, start_time)
         wday = step_time.wday
         offset = (day < wday) ? (7 - wday + day) : (day - wday)
         wrapper = TimeUtil::TimeWrapper.new(step_time)

--- a/lib/ice_cube/validations/day_of_year.rb
+++ b/lib/ice_cube/validations/day_of_year.rb
@@ -29,7 +29,7 @@ module IceCube
         true
       end
 
-      def validate(step_time, schedule)
+      def validate(step_time, start_time)
         days_in_year = TimeUtil.days_in_year(step_time)
         yday = day < 0 ? day + days_in_year + 1 : day
         offset = yday - step_time.yday

--- a/lib/ice_cube/validations/fixed_value.rb
+++ b/lib/ice_cube/validations/fixed_value.rb
@@ -12,11 +12,11 @@ module IceCube
 
     INTERVALS = {:min => 60, :sec => 60, :hour => 24, :month => 12, :wday => 7}
 
-    def validate(time, schedule)
+    def validate(time, start_time)
       case type
-      when :day  then validate_day_lock(time, schedule)
-      when :hour then validate_hour_lock(time, schedule)
-      else validate_interval_lock(time, schedule)
+      when :day  then validate_day_lock(time, start_time)
+      when :hour then validate_hour_lock(time, start_time)
+      else validate_interval_lock(time, start_time)
       end
     end
 
@@ -25,8 +25,8 @@ module IceCube
     # Validate if the current time unit matches the same unit from the schedule
     # start time, returning the difference to the interval
     #
-    def validate_interval_lock(time, schedule)
-      t0 = starting_unit(schedule.start_time)
+    def validate_interval_lock(time, start_time)
+      t0 = starting_unit(start_time)
       t1 = time.send(type)
       t0 >= t1 ? t0 - t1 : INTERVALS[type] - t1 + t0
     end
@@ -34,8 +34,8 @@ module IceCube
     # Lock the hour if explicitly set by hour_of_day, but allow for the nearest
     # hour during DST start to keep the correct interval.
     #
-    def validate_hour_lock(time, schedule)
-      h0 = starting_unit(schedule.start_time)
+    def validate_hour_lock(time, start_time)
+      h0 = starting_unit(start_time)
       h1 = time.hour
       if h0 >= h1
         h0 - h1
@@ -57,7 +57,7 @@ module IceCube
     # Positive day values are taken literally so months with fewer days will
     # be skipped.
     #
-    def validate_day_lock(time, schedule)
+    def validate_day_lock(time, start_time)
       days_in_month = TimeUtil.days_in_month(time)
       date = Date.new(time.year, time.month, time.day)
 
@@ -68,7 +68,7 @@ module IceCube
         start = value
         month_overflow = 0
       else
-        start = TimeUtil.day_of_month(schedule.start_time.day, date)
+        start = TimeUtil.day_of_month(start_time.day, date)
         month_overflow = 0
       end
 

--- a/lib/ice_cube/validations/hourly_interval.rb
+++ b/lib/ice_cube/validations/hourly_interval.rb
@@ -25,8 +25,8 @@ module IceCube
         false
       end
 
-      def validate(step_time, schedule)
-        t0, t1 = schedule.start_time.to_i, step_time.to_i
+      def validate(step_time, start_time)
+        t0, t1 = start_time.to_i, step_time.to_i
         sec = (t1 - t1 % ONE_HOUR) -
               (t0 - t0 % ONE_HOUR)
         hours = sec / ONE_HOUR

--- a/lib/ice_cube/validations/lock.rb
+++ b/lib/ice_cube/validations/lock.rb
@@ -12,11 +12,11 @@ module IceCube
 
     INTERVALS = {:min => 60, :sec => 60, :hour => 24, :month => 12, :wday => 7}
 
-    def validate(time, schedule)
+    def validate(time, start_time)
       case type
-      when :day  then validate_day_lock(time, schedule)
-      when :hour then validate_hour_lock(time, schedule)
-      else validate_interval_lock(time, schedule)
+      when :day  then validate_day_lock(time, start_time)
+      when :hour then validate_hour_lock(time, start_time)
+      else validate_interval_lock(time, start_time)
       end
     end
 
@@ -25,8 +25,8 @@ module IceCube
     # Validate if the current time unit matches the same unit from the schedule
     # start time, returning the difference to the interval
     #
-    def validate_interval_lock(time, schedule)
-      t0 = starting_unit(schedule.start_time)
+    def validate_interval_lock(time, start_time)
+      t0 = starting_unit(start_time)
       t1 = time.send(type)
       t0 >= t1 ? t0 - t1 : INTERVALS[type] - t1 + t0
     end
@@ -34,8 +34,8 @@ module IceCube
     # Lock the hour if explicitly set by hour_of_day, but allow for the nearest
     # hour during DST start to keep the correct interval.
     #
-    def validate_hour_lock(time, schedule)
-      h0 = starting_unit(schedule.start_time)
+    def validate_hour_lock(time, start_time)
+      h0 = starting_unit(start_time)
       h1 = time.hour
       if h0 >= h1
         h0 - h1
@@ -57,7 +57,7 @@ module IceCube
     # Positive day values are taken literally so months with fewer days will
     # be skipped.
     #
-    def validate_day_lock(time, schedule)
+    def validate_day_lock(time, start_time)
       days_in_month = TimeUtil.days_in_month(time)
       date = Date.new(time.year, time.month, time.day)
 
@@ -68,7 +68,7 @@ module IceCube
         start = value
         month_overflow = 0
       else
-        start = TimeUtil.day_of_month(schedule.start_time.day, date)
+        start = TimeUtil.day_of_month(start_time.day, date)
         month_overflow = 0
       end
 

--- a/lib/ice_cube/validations/minutely_interval.rb
+++ b/lib/ice_cube/validations/minutely_interval.rb
@@ -25,8 +25,8 @@ module IceCube
         false
       end
 
-      def validate(step_time, schedule)
-        t0, t1 = schedule.start_time.to_i, step_time.to_i
+      def validate(step_time, start_time)
+        t0, t1 = start_time.to_i, step_time.to_i
         sec = (t1 - t1 % ONE_MINUTE) -
               (t0 - t0 % ONE_MINUTE)
         minutes = sec / ONE_MINUTE

--- a/lib/ice_cube/validations/monthly_interval.rb
+++ b/lib/ice_cube/validations/monthly_interval.rb
@@ -25,8 +25,8 @@ module IceCube
         true
       end
 
-      def validate(step_time, schedule)
-        t0, t1 = schedule.start_time, step_time
+      def validate(step_time, start_time)
+        t0, t1 = start_time, step_time
         months = (t1.month - t0.month) +
                  (t1.year - t0.year) * 12
         offset = (months % interval).nonzero?

--- a/lib/ice_cube/validations/secondly_interval.rb
+++ b/lib/ice_cube/validations/secondly_interval.rb
@@ -25,8 +25,8 @@ module IceCube
         false
       end
 
-      def validate(step_time, schedule)
-        seconds = step_time.to_i - schedule.start_time.to_i
+      def validate(step_time, start_time)
+        seconds = step_time.to_i - start_time.to_i
         offset = (seconds % interval).nonzero?
         interval - offset if offset
       end

--- a/lib/ice_cube/validations/until.rb
+++ b/lib/ice_cube/validations/until.rb
@@ -32,8 +32,8 @@ module IceCube
         false
       end
 
-      def validate(step_time, schedule)
-        end_time = TimeUtil.ensure_time(time, schedule.start_time, true)
+      def validate(step_time, start_time)
+        end_time = TimeUtil.ensure_time(time, start_time, true)
         raise UntilExceeded if step_time > end_time
       end
 

--- a/lib/ice_cube/validations/weekly_interval.rb
+++ b/lib/ice_cube/validations/weekly_interval.rb
@@ -30,6 +30,7 @@ module IceCube
       end
 
       def validate(step_time, start_time)
+        return if step_time < start_time
         t0, t1 = start_time, step_time
         d0 = Date.new(t0.year, t0.month, t0.day)
         d1 = Date.new(t1.year, t1.month, t1.day)

--- a/lib/ice_cube/validations/weekly_interval.rb
+++ b/lib/ice_cube/validations/weekly_interval.rb
@@ -12,10 +12,6 @@ module IceCube
       self
     end
 
-    def week_start
-      @week_start
-    end
-
     class Validation
 
       attr_reader :interval, :week_start

--- a/lib/ice_cube/validations/weekly_interval.rb
+++ b/lib/ice_cube/validations/weekly_interval.rb
@@ -33,8 +33,8 @@ module IceCube
         true
       end
 
-      def validate(step_time, schedule)
-        t0, t1 = schedule.start_time, step_time
+      def validate(step_time, start_time)
+        t0, t1 = start_time, step_time
         d0 = Date.new(t0.year, t0.month, t0.day)
         d1 = Date.new(t1.year, t1.month, t1.day)
         days = (d1 - TimeUtil.normalize_wday(d1.wday, week_start)) -

--- a/lib/ice_cube/validations/yearly_interval.rb
+++ b/lib/ice_cube/validations/yearly_interval.rb
@@ -25,8 +25,8 @@ module IceCube
         true
       end
 
-      def validate(step_time, schedule)
-        years = step_time.year - schedule.start_time.year
+      def validate(step_time, start_time)
+        years = step_time.year - start_time.year
         offset = (years % interval).nonzero?
         interval - offset if offset
       end

--- a/spec/examples/daily_rule_spec.rb
+++ b/spec/examples/daily_rule_spec.rb
@@ -62,10 +62,10 @@ module IceCube
     end
 
     it 'should update previous interval' do
-      schedule = double(start_time: t0 = Time.now)
+      t0 = Time.now
       rule = Rule.daily(7)
       rule.interval(5)
-      expect(rule.next_time(t0 + 1, schedule, nil)).to eq(t0 + 5 * ONE_DAY)
+      expect(rule.next_time(t0 + 1, t0, nil)).to eq(t0 + 5 * ONE_DAY)
     end
 
     it 'should produce the correct days for @interval = 1' do

--- a/spec/examples/hourly_rule_spec.rb
+++ b/spec/examples/hourly_rule_spec.rb
@@ -52,10 +52,10 @@ module IceCube
     end
 
     it 'should update previous interval' do
-      schedule = double(start_time: t0 = Time.now)
+      t0 = Time.now
       rule = Rule.hourly(7)
       rule.interval(5)
-      expect(rule.next_time(t0 + 1, schedule, nil)).to eq(t0 + 5 * ONE_HOUR)
+      expect(rule.next_time(t0 + 1, t0, nil)).to eq(t0 + 5 * ONE_HOUR)
     end
 
     it 'should produce the correct days for @interval = 3' do

--- a/spec/examples/ice_cube_spec.rb
+++ b/spec/examples/ice_cube_spec.rb
@@ -331,26 +331,6 @@ describe IceCube::Schedule do
     expect(dates).to eq([start_time + IceCube::ONE_DAY * 2, start_time + IceCube::ONE_DAY * 3, start_time + IceCube::ONE_DAY * 4])
   end
 
-  describe "using occurs_between with a biweekly schedule" do
-    [[0, 1, 2], [0, 6, 1], [5, 1, 6], [6, 5, 7]].each do |wday, offset, lead|
-      start_week    = Time.utc(2014, 1, 5)
-      expected_week =  start_week + (IceCube::ONE_DAY * 14)
-      offset_wday   = (wday + offset) % 7
-
-      context "starting on weekday #{wday} selecting weekday #{offset} with a #{lead} day advance window" do
-        let(:biweekly)      { IceCube::Rule.weekly(2).day(0, 1, 2, 3, 4, 5, 6) }
-        let(:schedule)      { IceCube::Schedule.new(start_week + (IceCube::ONE_DAY * wday)) { |s| s.rrule biweekly } }
-        let(:expected_date) { expected_week + (IceCube::ONE_DAY * offset_wday) }
-        let(:range)         { [expected_date - (IceCube::ONE_DAY * lead), expected_date] }
-
-        it "should include weekday #{offset_wday} of the expected week" do
-          expect(schedule.occurrences_between(range.first, range.last)).to include expected_date
-        end
-      end
-
-    end
-  end
-
   it 'should be able to tell us when there is at least one occurrence between two dates' do
     start_time = WEDNESDAY
     schedule = IceCube::Schedule.new(start_time)

--- a/spec/examples/minutely_rule_spec.rb
+++ b/spec/examples/minutely_rule_spec.rb
@@ -29,10 +29,10 @@ module IceCube
   describe MinutelyRule do
 
     it 'should update previous interval' do
-      schedule = double(start_time: t0 = Time.now)
+      t0 = Time.now
       rule = Rule.minutely(7)
       rule.interval(5)
-      expect(rule.next_time(t0 + 1, schedule, nil)).to eq(t0 + 5 * IceCube::ONE_MINUTE)
+      expect(rule.next_time(t0 + 1, t0, nil)).to eq(t0 + 5 * IceCube::ONE_MINUTE)
     end
 
     it 'should work across DST start hour' do

--- a/spec/examples/monthly_rule_spec.rb
+++ b/spec/examples/monthly_rule_spec.rb
@@ -33,10 +33,10 @@ module IceCube
   describe MonthlyRule do
 
     it 'should update previous interval' do
-      schedule = double(start_time: t0 = Time.utc(2013, 5, 17))
+      t0 = Time.utc(2013, 5, 17)
       rule = Rule.monthly(3)
       rule.interval(1)
-      expect(rule.next_time(t0 + 1, schedule, nil)).to eq(t0 + (IceCube::ONE_DAY * 31))
+      expect(rule.next_time(t0 + 1, t0, nil)).to eq(t0 + (IceCube::ONE_DAY * 31))
     end
 
     it 'should produce the correct number of days for @interval = 1' do

--- a/spec/examples/validated_rule_spec.rb
+++ b/spec/examples/validated_rule_spec.rb
@@ -8,52 +8,43 @@ describe IceCube, "::ValidatedRule" do
       let(:rule) { IceCube::Rule.monthly }
 
       it "Should return current day when starting on same day" do
-        first = Time.new(2013, 2, 25, 0, 0, 0)
-        schedule = IceCube::Schedule.new(first)
-        schedule.add_recurrence_rule rule
-        expect(rule.next_time(first, schedule, nil)).to eq(first)
+        t0 = Time.new(2013, 2, 25, 0, 0, 0)
+        expect(rule.next_time(t0, t0, nil)).to eq(t0)
       end
 
       it "Should return the next month when starting one second in the future" do
-        first = Time.new(2013, 2, 25, 0, 0, 0)
-        schedule = IceCube::Schedule.new(first)
-        schedule.add_recurrence_rule rule
-        expect(rule.next_time(first + 1, schedule, nil)).to eq(Time.new(2013, 3, 25, 0, 0, 0))
+        t0 = Time.new(2013, 2, 25, 0, 0, 0)
+        t1 = Time.new(2013, 3, 25, 0, 0, 0)
+        expect(rule.next_time(t0 + 1, t0, nil)).to eq t1
       end
 
       it 'should return the next month near end of longer month [#171]' do
-        schedule = IceCube::Schedule.new(Date.new 2013, 1, 1)
+        t0 = Time.new(2013, 1, 1)
+        t1 = Time.new(2013, 2, 1)
         [27, 28, 29, 30, 31].each do |day|
-          expect(rule.next_time(Time.new(2013, 1, day), schedule, nil)).to eq(Time.new(2013, 2, 1))
+          expect(rule.next_time(Time.new(2013, 1, day), t0, nil)).to eq t1
         end
       end
 
-      context "DST edge" do
-        before { Time.zone = "Europe/London" }
-        let(:first) { Time.zone.parse("Sun, 31 Mar 2013 00:00:00 GMT +00:00") }
-        let(:schedule) {
-          sc = IceCube::Schedule.new(first)
-          sc.add_recurrence_rule rule
-          sc
-        }
+      context "DST edge", system_time_zone: "Europe/London" do
+        let(:t0) { Time.local(2013, 3, 31) }
 
         it "should not return the same time on a DST edge when starting one second in the future (results in infinite loop [#98])" do
-          expect(rule.next_time(first + 1, schedule, nil).to_s).not_to eq(first.to_s)
+          expect(rule.next_time(t0 + 1, t0, nil)).to eq Time.local(2013, 4, 30)
         end
 
         it "previous failing test with DST edge taken into account" do
-          expect(rule.next_time(first + 1.hour + 1.second, schedule, nil).to_s).not_to eq(first.to_s)
+          expect(rule.next_time(t0 + ONE_HOUR + 1, t0, nil)).to eq Time.local(2013, 4, 30)
         end
       end
 
     end
 
     it 'should match times with usec' do
-      first_time = Time.new(2012, 12, 21, 12, 21, 12.12121212)
-      schedule = double(:start_time => first_time)
+      t0 = Time.new(2012, 12, 21, 12, 21, 12.12121212)
       rule = IceCube::Rule.secondly
 
-      expect(rule.next_time(first_time + 1, schedule, nil)).to eq(first_time + 1)
+      expect(rule.next_time(t0 + 1, t0, nil)).to eq(t0 + 1)
     end
   end
 end

--- a/spec/examples/weekly_rule_spec.rb
+++ b/spec/examples/weekly_rule_spec.rb
@@ -179,5 +179,62 @@ module IceCube
       expect { Rule.weekly(2, :someday) }.to raise_error(ArgumentError)
     end
 
+    it 'should produce correct days for bi-weekly interval, starting on a non-sunday' do
+      schedule = IceCube::Schedule.new(t0 = Time.local(2015, 3, 3))
+      schedule.add_recurrence_rule IceCube::Rule.weekly(2, :monday).day(:tuesday)
+      range_start = Time.local(2015, 3, 15)
+      times = schedule.occurrences_between(range_start, range_start + IceCube::ONE_WEEK)
+      expect(times.first).to eq Time.local(2015, 3, 17)
+    end
+
+    it 'should produce correct days for monday-based bi-weekly interval, starting on a sunday' do
+      schedule = IceCube::Schedule.new(t0 = Time.local(2015, 3, 1))
+      schedule.add_recurrence_rule IceCube::Rule.weekly(2, :monday).day(:sunday)
+      range_start = Time.local(2015, 3, 1)
+      times = schedule.occurrences_between(range_start, range_start + IceCube::ONE_WEEK)
+      expect(times.first).to eq Time.local(2015, 3, 1)
+    end
+
+    describe "using occurs_between with a biweekly schedule" do
+      [[0, 1, 2], [0, 6, 1], [5, 1, 6], [6, 5, 7]].each do |wday, offset, lead|
+        start_week    = Time.utc(2014, 1, 5)
+        expected_week =  start_week + (IceCube::ONE_DAY * 14)
+        offset_wday   = (wday + offset) % 7
+
+        context "starting on weekday #{wday} selecting weekday #{offset} with a #{lead} day advance window" do
+          let(:biweekly)      { IceCube::Rule.weekly(2).day(0, 1, 2, 3, 4, 5, 6) }
+          let(:schedule)      { IceCube::Schedule.new(start_week + (IceCube::ONE_DAY * wday)) { |s| s.rrule biweekly } }
+          let(:expected_date) { expected_week + (IceCube::ONE_DAY * offset_wday) }
+          let(:range)         { [expected_date - (IceCube::ONE_DAY * lead), expected_date] }
+
+          it "should include weekday #{offset_wday} of the expected week" do
+            expect(schedule.occurrences_between(range.first, range.last)).to include expected_date
+          end
+        end
+      end
+    end
+
+    describe "using occurs_between with a weekly schedule" do
+      [[6, 5, 7]].each do |wday, offset, lead|
+        start_week    = Time.utc(2014, 1, 5)
+        expected_week = start_week + ONE_WEEK
+        offset_wday   = (wday + offset) % 7
+
+        context "starting on weekday #{wday} selecting weekday #{offset} with a #{lead} day advance window" do
+          let(:weekly)        { IceCube::Rule.weekly(1).day(0, 1, 2, 3, 4, 5, 6) }
+          let(:schedule)      { IceCube::Schedule.new(start_week + wday * IceCube::ONE_DAY) { |s| s.rrule weekly } }
+          let(:expected_date) { expected_week + offset_wday * IceCube::ONE_DAY }
+          let(:range)         { [expected_date - lead * ONE_DAY, expected_date] }
+
+          it "should include weekday #{offset_wday} of the expected week" do
+            wday_of_start_week = start_week + wday * IceCube::ONE_DAY
+
+            expect(schedule.occurrences_between(range.first, range.last)).to include expected_date
+            expect(schedule.occurrences_between(range.first, range.last).first).to eq(wday_of_start_week)
+          end
+        end
+      end
+    end
+
   end
 end

--- a/spec/examples/weekly_rule_spec.rb
+++ b/spec/examples/weekly_rule_spec.rb
@@ -175,6 +175,14 @@ module IceCube
       expect(t3).to eq(t2)
     end
 
+    it 'finds correct next_occurrence for biweekly rules' do
+      schedule = IceCube::Schedule.new(Time.utc(2016, 3, 3))
+      schedule.add_recurrence_rule IceCube::Rule.weekly(2).day(:sunday)
+
+      result = schedule.next_occurrence(Time.utc(2016, 3, 3))
+      expect(result).to eq Time.utc(2016, 3, 13)
+    end
+
     it 'should validate week_start input' do
       expect { Rule.weekly(2, :someday) }.to raise_error(ArgumentError)
     end

--- a/spec/examples/weekly_rule_spec.rb
+++ b/spec/examples/weekly_rule_spec.rb
@@ -52,10 +52,10 @@ module IceCube
     end
 
     it 'should update previous interval' do
-      schedule = double(start_time: t0 = Time.new(2013, 1, 1))
+      t0 = Time.new(2013, 1, 1)
       rule = Rule.weekly(7)
       rule.interval(2)
-      expect(rule.next_time(t0 + 1, schedule, nil)).to eq(Time.new(2013, 1, 15))
+      expect(rule.next_time(t0 + 1, t0, nil)).to eq(t0 + 2 * ONE_WEEK)
     end
 
     it 'should produce the correct number of days for @interval = 1 with no weekdays specified' do

--- a/spec/examples/yearly_rule_spec.rb
+++ b/spec/examples/yearly_rule_spec.rb
@@ -28,10 +28,10 @@ end
 describe IceCube::YearlyRule do
 
   it 'should update previous interval' do
-    schedule = double(start_time: t0 = Time.utc(2013, 5, 1))
+    t0 = Time.utc(2013, 5, 1)
     rule = Rule.yearly(3)
     rule.interval(1)
-    expect(rule.next_time(t0 + 1, schedule, nil)).to eq(t0 + (IceCube::ONE_DAY * 365))
+    expect(rule.next_time(t0 + 1, t0, nil)).to eq(t0 + (IceCube::ONE_DAY * 365))
   end
 
   it 'should be able to specify complex yearly rules' do


### PR DESCRIPTION
This change corrects the wday offset to account for the week start option in weekly rules.

Some refactoring was done to avoid adding conditionals and more complexity into the Schedule class which was coordinating this:

- Rules no longer depend on a Schedule object to validate: to simplify, they only require Time objects and calculate the next time coordinate from them.
- Rules no longer have a second argument for `week_start` except for the Weekly rule that uses it. This is to avoid confusion about where this option is actually used.

Much thanks to #360 and #284 for spotting the core issue here.