### PR TITLE
Schedule can be compared as a value object

### DIFF
--- a/lib/ice_cube/rule.rb
+++ b/lib/ice_cube/rule.rb
@@ -27,8 +27,7 @@ module IceCube
     end
 
     def hash
-      h = to_hash
-      h.nil? ? super : h.hash
+      to_hash.hash
     end
 
     def to_ical

--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -386,6 +386,19 @@ module IceCube
       recurrence_rules.empty? || recurrence_rules.all?(&:terminating?)
     end
 
+    def hash
+      [
+        TimeUtil.hash(start_time), duration,
+        *@all_recurrence_rules.map(&:hash).sort!,
+        *@all_exception_rules.map(&:hash).sort!
+      ].hash
+    end
+
+    def eql?(other)
+      self.hash == other.hash
+    end
+    alias == eql?
+
     def self.dump(schedule)
       return schedule if schedule.nil? || schedule == ""
       schedule.to_yaml

--- a/lib/ice_cube/time_util.rb
+++ b/lib/ice_cube/time_util.rb
@@ -109,6 +109,14 @@ module IceCube
       end
     end
 
+    # Get a more precise equality for time objects
+    # Ruby provides a Time#hash method, but it fails to account for UTC
+    # offset (so the current date may be different) or DST rules (so the
+    # hour may be wrong for different schedule occurrences)
+    def self.hash(time)
+      [time, time.utc_offset, time.zone].hash
+    end
+
     # Check the deserialized time offset string against actual local time
     # offset to try and preserve the original offset for plain Ruby Time. If
     # the offset is the same as local we can assume the same original zone and

--- a/spec/examples/schedule_equality_spec.rb
+++ b/spec/examples/schedule_equality_spec.rb
@@ -1,0 +1,113 @@
+require 'spec_helper'
+
+module IceCube
+  describe Schedule do
+    let(:t0) { Time.utc(2017, 1, 1, 12, 34, 56) }
+    let(:s1) { IceCube::Schedule.new(t0) }
+    let(:s2) { IceCube::Schedule.new(t0) }
+
+    describe :eql? do
+      subject(:equality) { s1 == s2 }
+
+      it "should be true for same start time" do
+        should be true
+      end
+
+      it "should be false for different start time" do
+        s2.start_time = t0 + 1
+        should be false
+      end
+
+      it "should be false for UTC vs. British start time", system_time_zone: "Europe/London" do
+        s2.start_time = t0.getlocal
+        should be false
+      end
+
+      it "should be false with different offset" do
+        s1.start_time = s1.start_time.getlocal("-06:00")
+        s2.start_time = s1.start_time.getlocal("-05:00")
+        should be false
+      end
+
+      it "should be true with same static offset" do
+        s1.start_time = t0.getlocal("-08:00")
+        s2.start_time = t0.getlocal("-08:00")
+        should be true
+      end
+
+      it "should be false with local zone vs. static offset", system_time_zone: "America/Vancouver" do
+        s1.start_time = t0.getlocal
+        s2.start_time = t0.getlocal(s1.start_time.utc_offset)
+        should be false
+      end
+
+      it "should be false with different duration" do
+        s2.duration = ONE_HOUR
+        should be false
+      end
+
+      it "should be false with different end time" do
+        s2.end_time = s2.start_time + ONE_HOUR
+        should be false
+      end
+
+      context "with ActiveSupport", requires_active_support: true do
+        require 'active_support/time'
+        let(:utc_tz) { ActiveSupport::TimeZone["Etc/UTC"] }
+        let(:pst_tz) { ActiveSupport::TimeZone["America/Vancouver"] }
+        let(:est_tz) { ActiveSupport::TimeZone["America/New_York"] }
+        let(:activesupport_t0) { utc_tz.local(2017, 1, 1, 12, 34, 56) }
+
+        it "should be true for ActiveSupport UTC vs. standard UTC" do
+          s2.start_time = activesupport_t0
+          should be true
+        end
+
+        it "should be true for ActiveSupport TZ vs. standard TZ", system_time_zone: "America/Vancouver" do
+          s1.start_time = t0.getlocal
+          s2.start_time = activesupport_t0.in_time_zone(pst_tz)
+          should be true
+        end
+
+        it "should be false for different ActiveSupport zones" do
+          s2.start_time = activesupport_t0.in_time_zone(pst_tz)
+          s1.start_time = activesupport_t0.in_time_zone(est_tz)
+          should be false
+        end
+      end
+
+      it "should be true with same rrules in different order" do
+        s1.rrule Rule.weekly.day(:thursday)
+        s1.rrule Rule.monthly.day_of_month(1)
+        s2.rrule Rule.monthly.day_of_month(1)
+        s2.rrule Rule.weekly.day(:thursday)
+        should be true
+      end
+
+      it "should be false with different rrules" do
+        s1.rrule Rule.weekly
+        s2.rrule Rule.weekly(2)
+        should be false
+      end
+
+      it "should be true with same extimes in different order" do
+        s1.rrule Rule.hourly
+        s1.extime t0 + ONE_HOUR
+        s1.extime t0 + 3 * ONE_HOUR
+        s2.rrule Rule.hourly
+        s2.extime t0 + 3 * ONE_HOUR
+        s2.extime t0 + ONE_HOUR
+        should be true
+      end
+
+      it "should be false with different extimes" do
+        s1.rrule Rule.hourly
+        s1.extime t0 + ONE_HOUR
+        s1.rrule Rule.hourly
+        s2.extime t0 + 3 * ONE_HOUR
+        should be false
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Add `hash` and `==` methods to track in-place changes.

Fixes #310