### PR TITLE
 clarify error message when a nonpositive integer is passed to interval method

### DIFF
--- a/lib/ice_cube/validated_rule.rb
+++ b/lib/ice_cube/validated_rule.rb
@@ -137,7 +137,7 @@ module IceCube
 
     def normalized_interval(interval)
       int = interval.to_i
-      raise ArgumentError, "'#{interval}' is not a valid input for interval. Please pass an integer." unless int > 0
+      raise ArgumentError, "'#{interval}' is not a valid input for interval. Please pass a postive integer." unless int > 0
       int
     end
 

--- a/spec/examples/daily_rule_spec.rb
+++ b/spec/examples/daily_rule_spec.rb
@@ -15,13 +15,13 @@ module IceCube
     it 'raises an argument error when a bad value is passed using the interval method' do
       expect {
         rule = Rule.daily.interval("invalid")
-      }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass an integer.")
+      }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
     end
 
     it 'raises an argument error when a bad value is passed' do
       expect {
         rule = Rule.daily("invalid")
-      }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass an integer.")
+      }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
     end
   end
 

--- a/spec/examples/hourly_rule_spec.rb
+++ b/spec/examples/hourly_rule_spec.rb
@@ -16,13 +16,13 @@ module IceCube
       it 'raises an argument error when a bad value is passed' do
         expect {
           rule = Rule.hourly("invalid")
-        }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass an integer.")
+        }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
       end
 
       it 'raises an argument error when a bad value is passed using the interval method' do
         expect {
           rule = Rule.hourly.interval("invalid")
-        }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass an integer.")
+        }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
       end
     end
 

--- a/spec/examples/minutely_rule_spec.rb
+++ b/spec/examples/minutely_rule_spec.rb
@@ -15,13 +15,13 @@ module IceCube
     it 'raises an argument error when a bad value is passed' do
       expect {
         rule = Rule.minutely("invalid")
-      }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass an integer.")
+      }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
     end
 
     it 'raises an argument error when a bad value is passed when using the interval method' do
       expect {
         rule = Rule.minutely.interval("invalid")
-      }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass an integer.")
+      }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
     end
 
   end

--- a/spec/examples/monthly_rule_spec.rb
+++ b/spec/examples/monthly_rule_spec.rb
@@ -20,13 +20,13 @@ module IceCube
     it 'raises an argument error when a bad value is passed' do
       expect {
         rule = Rule.monthly("invalid")
-      }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass an integer.")
+      }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
     end
 
     it 'raises an argument error when a bad value is passed using the interval method' do
       expect {
         rule = Rule.monthly.interval("invalid")
-      }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass an integer.")
+      }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
     end
   end
 

--- a/spec/examples/secondly_rule_spec.rb
+++ b/spec/examples/secondly_rule_spec.rb
@@ -15,13 +15,13 @@ module IceCube
     it 'raises an argument error when a bad value is passed' do
       expect {
         rule = Rule.secondly("invalid")
-      }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass an integer.")
+      }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
     end
 
     it 'raises an argument error when a bad value is passed using the interval method' do
       expect {
         rule = Rule.secondly.interval("invalid")
-      }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass an integer.")
+      }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
     end
   end
 end

--- a/spec/examples/weekly_rule_spec.rb
+++ b/spec/examples/weekly_rule_spec.rb
@@ -15,13 +15,13 @@ module IceCube
     it 'raises an argument error when a bad value is passed' do
       expect {
         rule = Rule.weekly("invalid")
-      }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass an integer.")
+      }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
     end
 
     it 'raises an argument error when a bad value is passed using the interval method' do
       expect {
         rule = Rule.weekly.interval("invalid")
-      }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass an integer.")
+      }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
     end
   end
 

--- a/spec/examples/yearly_rule_spec.rb
+++ b/spec/examples/yearly_rule_spec.rb
@@ -14,13 +14,13 @@ describe IceCube::YearlyRule, 'interval validation' do
   it 'raises an argument error when a bad value is passed' do
     expect {
       rule = Rule.yearly("invalid")
-    }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass an integer.")
+    }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
   end
 
   it 'raises an argument error when a bad value is passed using the interval method' do
     expect {
       rule = Rule.yearly.interval("invalid")
-    }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass an integer.")
+    }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
   end
 
 end


### PR DESCRIPTION
Yesterday I meant to call `day_of_year(-1)` but wrote instead `yearly(-1)` and was rather confused when the error message `-1 is not a valid input for interval. Please pass an integer.` appeared.

This PR just updates the error message to specify that the integer must be positive.