### PR TITLE
[WIP] Fix #377 regression

### DIFF
--- a/lib/ice_cube/rule.rb
+++ b/lib/ice_cube/rule.rb
@@ -53,7 +53,7 @@ module IceCube
       raise MethodNotImplemented, "Expected to be overridden by subclasses"
     end
 
-    def next_time(time, schedule, closing_time)
+    def next_time(time, schedule, closing_time, spans_offset = 0)
     end
 
     def on?(time, schedule)

--- a/lib/ice_cube/single_occurrence_rule.rb
+++ b/lib/ice_cube/single_occurrence_rule.rb
@@ -13,7 +13,7 @@ module IceCube
       true
     end
 
-    def next_time(t, _, closing_time)
+    def next_time(t, _, closing_time, _ = 0)
       unless closing_time && closing_time < t
         time if time.to_i >= t.to_i
       end

--- a/lib/ice_cube/validated_rule.rb
+++ b/lib/ice_cube/validated_rule.rb
@@ -57,11 +57,12 @@ module IceCube
 
     # Compute the next time after (or including) the specified time in respect
     # to the given start time
-    def next_time(time, start_time, closing_time)
+    def next_time(time, start_time, closing_time, spans_offset = 0)
       @time = time
       unless @start_time
         @start_time = realign(time, start_time)
         @time = @start_time if @time < @start_time
+        @time = @time - spans_offset
       end
 
       return nil unless find_acceptable_time_before(closing_time)

--- a/spec/examples/weekly_rule_spec.rb
+++ b/spec/examples/weekly_rule_spec.rb
@@ -240,20 +240,31 @@ module IceCube
       expect(times.first).to eq Time.local(2015, 3, 1)
     end
 
+    it 'should produce correct days for a sunday based bi-weekly rule with the spans option' do
+      t0 = Time.local(2017, 1, 15, 9, 0, 0)
+      schedule = IceCube::Schedule.new(t0, :duration => IceCube::ONE_HOUR)
+      schedule.add_recurrence_rule IceCube::Rule.weekly(2).day(:sunday)
+      ts = schedule.remaining_occurrences_enumerator(t0, :spans => true).take(3)
+      expect(ts).to eq([t0, t0 + ONE_WEEK * 2, t0 + ONE_WEEK * 4])
+    end
+
     describe "using occurs_between with a biweekly schedule" do
       [[0, 1, 2], [0, 6, 1], [5, 1, 6], [6, 5, 7]].each do |wday, offset, lead|
-        start_week    = Time.utc(2014, 1, 5)
-        expected_week =  start_week + (IceCube::ONE_DAY * 14)
+        start_time    = Time.utc(2014, 1, 5, 9, 0, 0)
+        expected_time = start_time + (IceCube::ONE_DAY * 14)
         offset_wday   = (wday + offset) % 7
 
         context "starting on weekday #{wday} selecting weekday #{offset} with a #{lead} day advance window" do
           let(:biweekly)      { IceCube::Rule.weekly(2).day(0, 1, 2, 3, 4, 5, 6) }
-          let(:schedule)      { IceCube::Schedule.new(start_week + (IceCube::ONE_DAY * wday)) { |s| s.rrule biweekly } }
-          let(:expected_date) { expected_week + (IceCube::ONE_DAY * offset_wday) }
+          let(:schedule)      { IceCube::Schedule.new(start_time + (IceCube::ONE_DAY * wday), :duration => IceCube::ONE_HOUR) { |s| s.rrule biweekly } }
+          let(:expected_date) { expected_time + (IceCube::ONE_DAY * offset_wday) }
           let(:range)         { [expected_date - (IceCube::ONE_DAY * lead), expected_date] }
 
           it "should include weekday #{offset_wday} of the expected week" do
             expect(schedule.occurrences_between(range.first, range.last)).to include expected_date
+          end
+          it "should include weekday #{offset_wday} of the expected week with the spans option" do
+            expect(schedule.occurrences_between(range.first, range.last, :spans => true)).to include expected_date
           end
         end
       end


### PR DESCRIPTION
The recent refactor of the weekly rule realignment has raised an error. This PR adds tests to show the problem and an attempt to fix it (currently not working).

The problem is that the duration offset used to be applied to the initial time t1 in the enumerator after the realignment was applied, but it has now been pushed back to the rule, so the realignment was being done on the offset t1 rather than the original opening_time. See #377 