### PR TITLE
Fix weekly realignment for `spans: true` option

### DIFF
--- a/lib/ice_cube/rules/weekly_rule.rb
+++ b/lib/ice_cube/rules/weekly_rule.rb
@@ -41,7 +41,7 @@ module IceCube
       wday_validations = other_interval_validations.select { |v| v.type == :wday }
       return 0 if wday_validations.none?
 
-      days = (step_time - start_time).to_i / ONE_DAY
+      days = step_time.to_date - start_time.to_date
       interval = base_interval_validation.validate(step_time, start_time).to_i
       min_wday = wday_validations.map { |v| TimeUtil.normalize_wday(v.day, week_start) }.min
       step_wday = TimeUtil.normalize_wday(step_time.wday, week_start)

--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -428,7 +428,9 @@ module IceCube
       spans = options[:spans] == true && duration != 0
       Enumerator.new do |yielder|
         reset
-        t1 = full_required? ? start_time : opening_time - (spans ? duration : 0)
+        t1 = full_required? ? start_time : opening_time
+        t1 -= duration if spans
+        t1 = start_time if t1 < start_time
         loop do
           break unless (t0 = next_time(t1, closing_time))
           break if closing_time && t0 > closing_time


### PR DESCRIPTION
Clamp iteration to the schedule start time so the first iteration does not
appear to be a preceding day (or possibly week).

When using the `spans: true` option, reversing over the start time to cover the
entire duration can move the opening time into a previous day/week and cause
weekly realignment to jump into the next weekly interval.

Count whole days for realigning weekly offsets to prevent rounding down to the
previous day.

Fixes #394 