### PR TITLE
#398 Fix double DST occurrences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current
 
+* [BUGFIX]      Fix double DST occurrences (#398)
 * [BUGFIX]      Realign first wday for monday-based weekly rules (#402)
 * [BUGFIX]      Fix weekly realignment for `spans: true` option (#402)
 

--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -420,7 +420,7 @@ module IceCube
     # Find all of the occurrences for the schedule between opening_time
     # and closing_time
     # Iteration is unrolled in pairs to skip duplicate times in end of DST
-    def enumerate_occurrences(opening_time, closing_time = nil, options = {}, &block)
+    def enumerate_occurrences(opening_time, closing_time = nil, options = {})
       opening_time = TimeUtil.match_zone(opening_time, start_time)
       closing_time = TimeUtil.match_zone(closing_time, start_time)
       opening_time += start_time.subsec - opening_time.subsec rescue 0
@@ -435,7 +435,7 @@ module IceCube
           break unless (t0 = next_time(t1, closing_time))
           break if closing_time && t0 > closing_time
           if (spans ? (t0.end_time > opening_time) : (t0 >= opening_time))
-            yielder << (block_given? ? block.call(t0) : t0)
+            yielder << (block_given? ? yield(t0) : t0)
           end
           break unless (t1 = next_time(t0 + 1, closing_time))
           break if closing_time && t1 > closing_time

--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -437,16 +437,7 @@ module IceCube
           if (spans ? (t0.end_time > opening_time) : (t0 >= opening_time))
             yielder << (block_given? ? yield(t0) : t0)
           end
-          break unless (t1 = next_time(t0 + 1, closing_time))
-          break if closing_time && t1 > closing_time
-          if TimeUtil.same_clock?(t0, t1) && recurrence_rules.any?(&:dst_adjust?)
-            wind_back_dst
-            next (t1 += 1)
-          end
-          if (spans ? (t1.end_time > opening_time) : (t1 >= opening_time))
-            yielder << (block_given? ? block.call(t1) : t1)
-          end
-          next (t1 += 1)
+          t1 = t0 + 1
         end
       end
     end
@@ -462,7 +453,7 @@ module IceCube
             min_time
           end
         end
-        break nil unless min_time
+        break unless min_time
         next (time = min_time + 1) if exception_time?(min_time)
         break Occurrence.new(min_time, min_time + duration)
       end
@@ -510,12 +501,6 @@ module IceCube
         [implicit_start_occurrence_rule].concat @all_recurrence_rules
       else
         @all_recurrence_rules
-      end
-    end
-
-    def wind_back_dst
-      recurrence_rules.each do |rule|
-        rule.skipped_for_dst
       end
     end
 

--- a/spec/examples/dst_spec.rb
+++ b/spec/examples/dst_spec.rb
@@ -263,11 +263,10 @@ describe IceCube::Schedule do
     expect(schedule.first(3)).to eq([Time.local(2010, 4, 10, 12, 0, 0), Time.local(2011, 4, 10, 12, 0, 0), Time.local(2012, 4, 10, 12, 0, 0)])
   end
 
-  it "skips double occurrences from end of DST" do
-    Time.zone = "America/Denver"
-    t0 = Time.zone.parse("Sun, 03 Nov 2013 01:30:00 MDT -06:00")
+  it "skips double daily occurrences from end of DST", :system_time_zone => "America/Denver" do
+    t0 = Time.local(2013, 11, 3, 1, 30, 0)
     schedule = IceCube::Schedule.new(t0) { |s| s.rrule IceCube::Rule.daily.count(3) }
-    expect(schedule.all_occurrences).to eq([t0, t0 + 25*ONE_HOUR, t0 + 49*ONE_HOUR])
+    expect(schedule.all_occurrences).to eq([t0, Time.local(2013, 11, 4, 1, 30, 0), Time.local(2013, 11, 5, 1, 30, 0)])
   end
 
   it "skips double monthly occurrences from end of DST", :system_time_zone => "America/Nome" do
@@ -276,24 +275,21 @@ describe IceCube::Schedule do
     expect(schedule.all_occurrences).to eq([t0, t0 + 31*IceCube::ONE_DAY + IceCube::ONE_HOUR, t0 + 61*IceCube::ONE_DAY + IceCube::ONE_HOUR])
   end
 
-  it "does not skip hourly rules over DST" do
-    Time.zone = "America/Denver"
-    t0 = Time.zone.parse("Sun, 03 Nov 2013 01:30:00 MDT -06:00")
+  it "does not skip hourly rules over DST", :system_time_zone => "America/Denver" do
+    t0 = Time.local(2013, 11, 3, 1, 30, 0)
     schedule = IceCube::Schedule.new(t0) { |s| s.rrule IceCube::Rule.hourly.count(3) }
     expect(schedule.all_occurrences).to eq([t0, t0 + ONE_HOUR, t0 + 2*ONE_HOUR])
   end
 
-  it "does not skip minutely rules with minute of hour over DST" do
-    Time.zone = "America/Denver"
-    t0 = Time.zone.parse("Sun, 03 Nov 2013 01:30:00 MDT -06:00")
+  it "does not skip minutely rules with minute of hour over DST", :system_time_zone => "America/Denver" do
+    t0 = Time.local(2013, 11, 3, 1, 30, 0)
     schedule = IceCube::Schedule.new(t0) { |s| s.rrule IceCube::Rule.hourly.count(3) }
     schedule.rrule IceCube::Rule.minutely.minute_of_hour([0, 15, 30, 45])
     expect(schedule.first(5)).to eq([t0, t0 + 15*60, t0 + 30*60, t0 + 45*60, t0 + 60*60])
   end
 
-  it "does not skip minutely rules with second of minute over DST" do
-    Time.zone = "America/Denver"
-    t0 = Time.zone.parse("Sun, 03 Nov 2013 01:30:00 MDT -06:00")
+  it "does not skip minutely rules with second of minute over DST", :system_time_zone => "America/Denver" do
+    t0 = Time.local(2013, 11, 3, 1, 30, 0)
     schedule = IceCube::Schedule.new(t0) { |s| s.rrule IceCube::Rule.hourly.count(3) }
     schedule.rrule IceCube::Rule.minutely(15).second_of_minute(0)
     expect(schedule.first(5)).to eq([t0, t0 + 15*60, t0 + 30*60, t0 + 45*60, t0 + 60*60])

--- a/spec/examples/dst_spec.rb
+++ b/spec/examples/dst_spec.rb
@@ -1,299 +1,299 @@
 require File.dirname(__FILE__) + '/../spec_helper'
 
 module IceCube
-describe Schedule do
+  describe Schedule do
 
-  # DST in 2010 is March 14th at 2am
-  it 'crosses a daylight savings time boundary with a recurrence rule in local time, by utc conversion' do
-    start_time = Time.local(2010, 3, 13, 5, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.daily.count(20)
-    dates = schedule.first(20)
-    expect(dates.size).to eq(20)
-    #check assumptions
-    dates.each do |date|
-      expect(date.utc?).not_to eq(true)
-      expect(date.hour).to eq(5)
+    # DST in 2010 is March 14th at 2am
+    it 'crosses a daylight savings time boundary with a recurrence rule in local time, by utc conversion' do
+      start_time = Time.local(2010, 3, 13, 5, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.daily.count(20)
+      dates = schedule.first(20)
+      expect(dates.size).to eq(20)
+      # check assumptions
+      dates.each do |date|
+        expect(date.utc?).not_to eq(true)
+        expect(date.hour).to eq(5)
+      end
+    end
+
+    # DST in 2010 is November 7th at 2am
+    it 'crosses a daylight savings time boundary (in the other direction) with a recurrence rule in local time, by utc conversion' do
+      start_time = Time.local(2010, 11, 6, 5, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.daily.count(20)
+      dates = schedule.first(20)
+      expect(dates.size).to eq(20)
+      # check assumptions
+      dates.each do |date|
+        expect(date.utc?).not_to eq(true)
+        expect(date.hour).to eq(5)
+      end
+    end
+
+    it 'cross a daylight savings time boundary with a recurrence rule in local time' do
+      start_time = Time.local(2010, 3, 14, 5, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.daily
+      # each occurrence MUST occur at 5pm, then we win
+      dates = schedule.occurrences(start_time + 20 * ONE_DAY)
+      last = start_time
+      dates.each do |date|
+        expect(date.hour).to eq(5)
+        last = date
+      end
+    end
+
+    it 'every two hours over a daylight savings time boundary, checking interval' do
+      start_time = Time.local(2010, 11, 6, 5, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.hourly(2)
+      dates = schedule.first(100)
+      # check assumption
+      distance_in_hours = 0
+      dates.each do |d|
+        expect(d).to eq(start_time + ONE_HOUR * distance_in_hours)
+        distance_in_hours += 2
+      end
+    end
+
+    it 'every 30 minutes over a daylight savings time boundary, checking interval' do
+      start_time = Time.local(2010, 11, 6, 23, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.minutely(30)
+      dates = schedule.first(100)
+      # check assumption
+      distance_in_minutes = 0
+      dates.each do |d|
+        expect(d).to eq(start_time + ONE_MINUTE * distance_in_minutes)
+        distance_in_minutes += 30
+      end
+    end
+
+    it 'every 120 seconds over a daylight savings time boundary, checking interval' do
+      start_time = Time.local(2010, 11, 6, 23, 50, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.secondly(120)
+      dates = schedule.first(10)
+      # check assumption
+      distance_in_seconds = 0
+      dates.each do |d|
+        expect(d).to eq(start_time + distance_in_seconds)
+        distance_in_seconds += 120
+      end
+    end
+
+    it 'every other day over a daylight savings time boundary, checking hour/min/sec' do
+      start_time = Time.local(2010, 11, 6, 20, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.daily(2)
+      dates = schedule.first(10)
+      # check assumption
+      dates.each do |d|
+        expect(d.hour).to eq(start_time.hour)
+        expect(d.min).to eq(start_time.min)
+        expect(d.sec).to eq(start_time.sec)
+      end
+    end
+
+    it 'every other month over a daylight savings time boundary, checking day/hour/min/sec' do
+      start_time = Time.local(2010, 11, 6, 20, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.monthly(2)
+      dates = schedule.first(10)
+      # check assumption
+      dates.each do |d|
+        expect(d.day).to eq(start_time.day)
+        expect(d.hour).to eq(start_time.hour)
+        expect(d.min).to eq(start_time.min)
+        expect(d.sec).to eq(start_time.sec)
+      end
+    end
+
+    it 'every other year over a daylight savings time boundary, checking day/hour/min/sec' do
+      start_time = Time.local(2010, 11, 6, 20, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.yearly(2)
+      dates = schedule.first(10)
+      # check assumption
+      dates.each do |d|
+        expect(d.month).to eq(start_time.month)
+        expect(d.day).to eq(start_time.day)
+        expect(d.hour).to eq(start_time.hour)
+        expect(d.min).to eq(start_time.min)
+        expect(d.sec).to eq(start_time.sec)
+      end
+    end
+
+    it 'LOCAL - has an until date on a rule that is over a DST from the start date' do
+      start_time = Time.local(2010, 3, 13, 5, 0, 0)
+      end_date = Time.local(2010, 3, 15, 5, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.daily.until(end_date)
+      # make sure we end on the proper time
+      expect(schedule.all_occurrences.last).to eq(end_date)
+    end
+
+    it 'UTC - has an until date on a rule that is over a DST from the start date' do
+      start_time = Time.utc(2010, 3, 13, 5, 0, 0)
+      end_date = Time.utc(2010, 3, 15, 5, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.daily.until(end_date)
+      # make sure we end on the proper time
+      expect(schedule.all_occurrences.last).to eq(end_date)
+    end
+
+    it 'LOCAL - has an until date on a rule that is over a DST from the start date (other direction)' do
+      start_time = Time.local(2010, 11, 5, 5, 0, 0)
+      end_date = Time.local(2010, 11, 10, 5, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.daily.until(end_date)
+      # make sure we end on the proper time
+      expect(schedule.all_occurrences.last).to eq(end_date)
+    end
+
+    it 'UTC - has an until date on a rule that is over a DST from the start date (other direction)' do
+      start_time = Time.utc(2010, 11, 5, 5, 0, 0)
+      end_date = Time.utc(2010, 11, 10, 5, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.daily.until(end_date)
+      # make sure we end on the proper time
+      expect(schedule.all_occurrences.last).to eq(end_date)
+    end
+
+    it 'LOCAL - has an end date on a rule that is over a DST from the start date' do
+      start_time = Time.local(2010, 3, 13, 5, 0, 0)
+      end_date = Time.local(2010, 3, 15, 5, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.daily
+      # make sure we end on the proper time
+      expect(schedule.occurrences(end_date).last).to eq(end_date)
+    end
+
+    it 'UTC - has an end date on a rule that is over a DST from the start date' do
+      start_time = Time.utc(2010, 3, 13, 5, 0, 0)
+      end_date = Time.utc(2010, 3, 15, 5, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.daily
+      # make sure we end on the proper time
+      expect(schedule.occurrences(end_date).last).to eq(end_date)
+    end
+
+    it 'LOCAL - has an end date on a rule that is over a DST from the start date (other direction)' do
+      start_time = Time.local(2010, 11, 5, 5, 0, 0)
+      end_date = Time.local(2010, 11, 10, 5, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.daily
+      # make sure we end on the proper time
+      expect(schedule.occurrences(end_date).last).to eq(end_date)
+    end
+
+    it 'UTC - has an end date on a rule that is over a DST from the start date (other direction)' do
+      start_time = Time.utc(2010, 11, 5, 5, 0, 0)
+      end_date = Time.utc(2010, 11, 10, 5, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.daily
+      # make sure we end on the proper time
+      expect(schedule.occurrences(end_date).last).to eq(end_date)
+    end
+
+    it 'local - should make dates on interval over dst - github issue 4' do
+      start_time = Time.local(2010, 3, 12, 19, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.daily(3)
+      expect(schedule.first(3)).to eq([Time.local(2010, 3, 12, 19, 0, 0), Time.local(2010, 3, 15, 19, 0, 0), Time.local(2010, 3, 18, 19, 0, 0)])
+    end
+
+    it 'local - should make dates on monthly interval over dst - github issue 4' do
+      start_time = Time.local(2010, 3, 12, 19, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.monthly(2)
+      expect(schedule.first(6)).to eq([Time.local(2010, 3, 12, 19, 0, 0), Time.local(2010, 5, 12, 19, 0, 0), Time.local(2010, 7, 12, 19, 0, 0),
+                                       Time.local(2010, 9, 12, 19, 0, 0), Time.local(2010, 11, 12, 19, 0, 0), Time.local(2011, 1, 12, 19, 0, 0)])
+    end
+
+    it 'local - should make dates on monthly interval over dst - github issue 4' do
+      start_time = Time.local(2010, 3, 12, 19, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.monthly
+      expect(schedule.first(10)).to eq([Time.local(2010, 3, 12, 19, 0, 0), Time.local(2010, 4, 12, 19, 0, 0), Time.local(2010, 5, 12, 19, 0, 0),
+                                        Time.local(2010, 6, 12, 19, 0, 0), Time.local(2010, 7, 12, 19, 0, 0), Time.local(2010, 8, 12, 19, 0, 0),
+                                        Time.local(2010, 9, 12, 19, 0, 0), Time.local(2010, 10, 12, 19, 0, 0), Time.local(2010, 11, 12, 19, 0, 0),
+                                        Time.local(2010, 12, 12, 19, 0, 0)])
+    end
+
+    it 'local - should make dates on yearly interval over dst - github issue 4' do
+      start_time = Time.local(2010, 3, 12, 19, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.yearly(2)
+      expect(schedule.first(3)).to eq([Time.local(2010, 3, 12, 19, 0, 0), Time.local(2012, 3, 12, 19, 0, 0), Time.local(2014, 3, 12, 19, 0, 0)])
+    end
+
+    it "local - should make dates on monthly (day of week) inverval over dst - github issue 5" do
+      start_time = Time.local(2010, 3, 7, 12, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.monthly.day_of_week(:sunday => [1])
+      expect(schedule.first(3)).to eq([Time.local(2010, 3, 7, 12, 0, 0), Time.local(2010, 4, 4, 12, 0, 0), Time.local(2010, 5, 2, 12, 0, 0)])
+    end
+
+    it "local - should make dates on monthly (day of month) inverval over dst - github issue 5" do
+      start_time = Time.local(2010, 3, 1, 12, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.monthly.day_of_month(1)
+      expect(schedule.first(3)).to eq([Time.local(2010, 3, 1, 12, 0, 0), Time.local(2010, 4, 1, 12, 0, 0), Time.local(2010, 5, 1, 12, 0, 0)])
+    end
+
+    it "local - should make dates on weekly (day) inverval over dst - github issue 5" do
+      start_time = Time.local(2010, 3, 7, 12, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.weekly.day(:sunday)
+      expect(schedule.first(3)).to eq([Time.local(2010, 3, 7, 12, 0, 0), Time.local(2010, 3, 14, 12, 0, 0), Time.local(2010, 3, 21, 12, 0, 0)])
+    end
+
+    it "local - should make dates on monthly (day of year) inverval over dst - github issue 5" do
+      start_time = Time.local(2010, 3, 7, 12, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.monthly.day_of_year(1)
+      expect(schedule.first(3)).to eq([Time.local(2011, 1, 1, 12, 0, 0), Time.local(2012, 1, 1, 12, 0, 0), Time.local(2013, 1, 1, 12, 0, 0)])
+    end
+
+    it "local - should make dates on monthly (month_of_year) inverval over dst - github issue 5" do
+      start_time = Time.local(2010, 3, 7, 12, 0, 0)
+      schedule = Schedule.new(start_time)
+      schedule.add_recurrence_rule Rule.yearly.month_of_year(:april).day_of_month(10)
+      expect(schedule.first(3)).to eq([Time.local(2010, 4, 10, 12, 0, 0), Time.local(2011, 4, 10, 12, 0, 0), Time.local(2012, 4, 10, 12, 0, 0)])
+    end
+
+    it "skips double daily occurrences from end of DST", :system_time_zone => "America/Denver" do
+      t0 = Time.local(2013, 11, 3, 1, 30, 0)
+      schedule = Schedule.new(t0) { |s| s.rrule Rule.daily.count(3) }
+      expect(schedule.all_occurrences).to eq([t0, Time.local(2013, 11, 4, 1, 30, 0), Time.local(2013, 11, 5, 1, 30, 0)])
+    end
+
+    it "skips double monthly occurrences from end of DST", :system_time_zone => "America/Nome" do
+      t0 = Time.local(2017, 10, 5, 1, 0, 0)
+      schedule = Schedule.new(t0) { |s| s.rrule Rule.monthly.day_of_month(5).count(3) }
+      expect(schedule.all_occurrences).to eq([t0, t0 + 31*ONE_DAY + ONE_HOUR, t0 + 61*ONE_DAY + ONE_HOUR])
+    end
+
+    it "does not skip hourly rules over DST", :system_time_zone => "America/Denver" do
+      t0 = Time.local(2013, 11, 3, 1, 30, 0)
+      schedule = Schedule.new(t0) { |s| s.rrule Rule.hourly.count(3) }
+      expect(schedule.all_occurrences).to eq([t0, t0 + ONE_HOUR, t0 + 2*ONE_HOUR])
+    end
+
+    it "does not skip minutely rules with minute of hour over DST", :system_time_zone => "America/Denver" do
+      t0 = Time.local(2013, 11, 3, 1, 30, 0)
+      schedule = Schedule.new(t0) { |s| s.rrule Rule.hourly.count(3) }
+      schedule.rrule Rule.minutely.minute_of_hour([0, 15, 30, 45])
+      expect(schedule.first(5)).to eq([t0, t0 + 15*60, t0 + 30*60, t0 + 45*60, t0 + 60*60])
+    end
+
+    it "does not skip minutely rules with second of minute over DST", :system_time_zone => "America/Denver" do
+      t0 = Time.local(2013, 11, 3, 1, 30, 0)
+      schedule = Schedule.new(t0) { |s| s.rrule Rule.hourly.count(3) }
+      schedule.rrule Rule.minutely(15).second_of_minute(0)
+      expect(schedule.first(5)).to eq([t0, t0 + 15*60, t0 + 30*60, t0 + 45*60, t0 + 60*60])
     end
   end
-
-  # DST in 2010 is November 7th at 2am
-  it 'crosses a daylight savings time boundary (in the other direction) with a recurrence rule in local time, by utc conversion' do
-    start_time = Time.local(2010, 11, 6, 5, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.daily.count(20)
-    dates = schedule.first(20)
-    expect(dates.size).to eq(20)
-    #check assumptions
-    dates.each do |date|
-      expect(date.utc?).not_to eq(true)
-      expect(date.hour).to eq(5)
-    end
-  end
-
-  it 'cross a daylight savings time boundary with a recurrence rule in local time' do
-    start_time = Time.local(2010, 3, 14, 5, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.daily
-    # each occurrence MUST occur at 5pm, then we win
-    dates = schedule.occurrences(start_time + 20 * ONE_DAY)
-    last = start_time
-    dates.each do |date|
-      expect(date.hour).to eq(5)
-      last = date
-    end
-  end
-
-  it 'every two hours over a daylight savings time boundary, checking interval' do
-    start_time = Time.local(2010, 11, 6, 5, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.hourly(2)
-    dates = schedule.first(100)
-    #check assumption
-    distance_in_hours = 0
-    dates.each do |d|
-      expect(d).to eq(start_time + ONE_HOUR * distance_in_hours)
-      distance_in_hours += 2
-    end
-  end
-
-  it 'every 30 minutes over a daylight savings time boundary, checking interval' do
-    start_time = Time.local(2010, 11, 6, 23, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.minutely(30)
-    dates = schedule.first(100)
-    #check assumption
-    distance_in_minutes = 0
-    dates.each do |d|
-      expect(d).to eq(start_time + ONE_MINUTE * distance_in_minutes)
-      distance_in_minutes += 30
-    end
-  end
-
-  it 'every 120 seconds over a daylight savings time boundary, checking interval' do
-    start_time = Time.local(2010, 11, 6, 23, 50, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.secondly(120)
-    dates = schedule.first(10)
-    #check assumption
-    distance_in_seconds = 0
-    dates.each do |d|
-      expect(d).to eq(start_time + distance_in_seconds)
-      distance_in_seconds += 120
-    end
-  end
-
-  it 'every other day over a daylight savings time boundary, checking hour/min/sec' do
-    start_time = Time.local(2010, 11, 6, 20, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.daily(2)
-    dates = schedule.first(10)
-    #check assumption
-    dates.each do |d|
-      expect(d.hour).to eq(start_time.hour)
-      expect(d.min).to eq(start_time.min)
-      expect(d.sec).to eq(start_time.sec)
-    end
-  end
-
-  it 'every other month over a daylight savings time boundary, checking day/hour/min/sec' do
-    start_time = Time.local(2010, 11, 6, 20, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.monthly(2)
-    dates = schedule.first(10)
-    #check assumption
-    dates.each do |d|
-      expect(d.day).to eq(start_time.day)
-      expect(d.hour).to eq(start_time.hour)
-      expect(d.min).to eq(start_time.min)
-      expect(d.sec).to eq(start_time.sec)
-    end
-  end
-
-  it 'every other year over a daylight savings time boundary, checking day/hour/min/sec' do
-    start_time = Time.local(2010, 11, 6, 20, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.yearly(2)
-    dates = schedule.first(10)
-    #check assumption
-    dates.each do |d|
-      expect(d.month).to eq(start_time.month)
-      expect(d.day).to eq(start_time.day)
-      expect(d.hour).to eq(start_time.hour)
-      expect(d.min).to eq(start_time.min)
-      expect(d.sec).to eq(start_time.sec)
-    end
-  end
-
-  it 'LOCAL - has an until date on a rule that is over a DST from the start date' do
-    start_time = Time.local(2010, 3, 13, 5, 0, 0)
-    end_date = Time.local(2010, 3, 15, 5, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.daily.until(end_date)
-    #make sure we end on the proper time
-    expect(schedule.all_occurrences.last).to eq(end_date)
-  end
-
-  it 'UTC - has an until date on a rule that is over a DST from the start date' do
-    start_time = Time.utc(2010, 3, 13, 5, 0, 0)
-    end_date = Time.utc(2010, 3, 15, 5, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.daily.until(end_date)
-    #make sure we end on the proper time
-    expect(schedule.all_occurrences.last).to eq(end_date)
-  end
-
-  it 'LOCAL - has an until date on a rule that is over a DST from the start date (other direction)' do
-    start_time = Time.local(2010, 11, 5, 5, 0, 0)
-    end_date = Time.local(2010, 11, 10, 5, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.daily.until(end_date)
-    #make sure we end on the proper time
-    expect(schedule.all_occurrences.last).to eq(end_date)
-  end
-
-  it 'UTC - has an until date on a rule that is over a DST from the start date (other direction)' do
-    start_time = Time.utc(2010, 11, 5, 5, 0, 0)
-    end_date = Time.utc(2010, 11, 10, 5, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.daily.until(end_date)
-    #make sure we end on the proper time
-    expect(schedule.all_occurrences.last).to eq(end_date)
-  end
-
-  it 'LOCAL - has an end date on a rule that is over a DST from the start date' do
-    start_time = Time.local(2010, 3, 13, 5, 0, 0)
-    end_date = Time.local(2010, 3, 15, 5, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.daily
-    #make sure we end on the proper time
-    expect(schedule.occurrences(end_date).last).to eq(end_date)
-  end
-
-  it 'UTC - has an end date on a rule that is over a DST from the start date' do
-    start_time = Time.utc(2010, 3, 13, 5, 0, 0)
-    end_date = Time.utc(2010, 3, 15, 5, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.daily
-    #make sure we end on the proper time
-    expect(schedule.occurrences(end_date).last).to eq(end_date)
-  end
-
-  it 'LOCAL - has an end date on a rule that is over a DST from the start date (other direction)' do
-    start_time = Time.local(2010, 11, 5, 5, 0, 0)
-    end_date = Time.local(2010, 11, 10, 5, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.daily
-    #make sure we end on the proper time
-    expect(schedule.occurrences(end_date).last).to eq(end_date)
-  end
-
-  it 'UTC - has an end date on a rule that is over a DST from the start date (other direction)' do
-    start_time = Time.utc(2010, 11, 5, 5, 0, 0)
-    end_date = Time.utc(2010, 11, 10, 5, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.daily
-    #make sure we end on the proper time
-    expect(schedule.occurrences(end_date).last).to eq(end_date)
-  end
-
-  it 'local - should make dates on interval over dst - github issue 4' do
-    start_time = Time.local(2010, 3, 12, 19, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.daily(3)
-    expect(schedule.first(3)).to eq([Time.local(2010, 3, 12, 19, 0, 0), Time.local(2010, 3, 15, 19, 0, 0), Time.local(2010, 3, 18, 19, 0, 0)])
-  end
-
-  it 'local - should make dates on monthly interval over dst - github issue 4' do
-    start_time = Time.local(2010, 3, 12, 19, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.monthly(2)
-    expect(schedule.first(6)).to eq([Time.local(2010, 3, 12, 19, 0, 0), Time.local(2010, 5, 12, 19, 0, 0), Time.local(2010, 7, 12, 19, 0, 0),
-                                 Time.local(2010, 9, 12, 19, 0, 0), Time.local(2010, 11, 12, 19, 0, 0), Time.local(2011, 1, 12, 19, 0, 0)])
-  end
-
-  it 'local - should make dates on monthly interval over dst - github issue 4' do
-    start_time = Time.local(2010, 3, 12, 19, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.monthly
-    expect(schedule.first(10)).to eq([Time.local(2010, 3, 12, 19, 0, 0), Time.local(2010, 4, 12, 19, 0, 0), Time.local(2010, 5, 12, 19, 0, 0),
-                                  Time.local(2010, 6, 12, 19, 0, 0), Time.local(2010, 7, 12, 19, 0, 0), Time.local(2010, 8, 12, 19, 0, 0),
-                                  Time.local(2010, 9, 12, 19, 0, 0), Time.local(2010, 10, 12, 19, 0, 0), Time.local(2010, 11, 12, 19, 0, 0),
-                                  Time.local(2010, 12, 12, 19, 0, 0)])
-  end
-
-  it 'local - should make dates on yearly interval over dst - github issue 4' do
-    start_time = Time.local(2010, 3, 12, 19, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.yearly(2)
-    expect(schedule.first(3)).to eq([Time.local(2010, 3, 12, 19, 0, 0), Time.local(2012, 3, 12, 19, 0, 0), Time.local(2014, 3, 12, 19, 0, 0)])
-  end
-
-  it "local - should make dates on monthly (day of week) inverval over dst - github issue 5" do
-    start_time = Time.local(2010, 3, 7, 12, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.monthly.day_of_week(:sunday => [1])
-    expect(schedule.first(3)).to eq([Time.local(2010, 3, 7, 12, 0, 0), Time.local(2010, 4, 4, 12, 0, 0), Time.local(2010, 5, 2, 12, 0, 0)])
-  end
-
-  it "local - should make dates on monthly (day of month) inverval over dst - github issue 5" do
-    start_time = Time.local(2010, 3, 1, 12, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.monthly.day_of_month(1)
-    expect(schedule.first(3)).to eq([Time.local(2010, 3, 1, 12, 0, 0), Time.local(2010, 4, 1, 12, 0, 0), Time.local(2010, 5, 1, 12, 0, 0)])
-  end
-
-  it "local - should make dates on weekly (day) inverval over dst - github issue 5" do
-    start_time = Time.local(2010, 3, 7, 12, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.weekly.day(:sunday)
-    expect(schedule.first(3)).to eq([Time.local(2010, 3, 7, 12, 0, 0), Time.local(2010, 3, 14, 12, 0, 0), Time.local(2010, 3, 21, 12, 0, 0)])
-  end
-
-  it "local - should make dates on monthly (day of year) inverval over dst - github issue 5" do
-    start_time = Time.local(2010, 3, 7, 12, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.monthly.day_of_year(1)
-    expect(schedule.first(3)).to eq([Time.local(2011, 1, 1, 12, 0, 0), Time.local(2012, 1, 1, 12, 0, 0), Time.local(2013, 1, 1, 12, 0, 0)])
-  end
-
-  it "local - should make dates on monthly (month_of_year) inverval over dst - github issue 5" do
-    start_time = Time.local(2010, 3, 7, 12, 0, 0)
-    schedule = Schedule.new(start_time)
-    schedule.add_recurrence_rule Rule.yearly.month_of_year(:april).day_of_month(10)
-    expect(schedule.first(3)).to eq([Time.local(2010, 4, 10, 12, 0, 0), Time.local(2011, 4, 10, 12, 0, 0), Time.local(2012, 4, 10, 12, 0, 0)])
-  end
-
-  it "skips double daily occurrences from end of DST", :system_time_zone => "America/Denver" do
-    t0 = Time.local(2013, 11, 3, 1, 30, 0)
-    schedule = Schedule.new(t0) { |s| s.rrule Rule.daily.count(3) }
-    expect(schedule.all_occurrences).to eq([t0, Time.local(2013, 11, 4, 1, 30, 0), Time.local(2013, 11, 5, 1, 30, 0)])
-  end
-
-  it "skips double monthly occurrences from end of DST", :system_time_zone => "America/Nome" do
-    t0 = Time.local(2017, 10, 5, 1, 0, 0)
-    schedule = Schedule.new(t0) { |s| s.rrule Rule.monthly.day_of_month(5).count(3) }
-    expect(schedule.all_occurrences).to eq([t0, t0 + 31*ONE_DAY + ONE_HOUR, t0 + 61*ONE_DAY + ONE_HOUR])
-  end
-
-  it "does not skip hourly rules over DST", :system_time_zone => "America/Denver" do
-    t0 = Time.local(2013, 11, 3, 1, 30, 0)
-    schedule = Schedule.new(t0) { |s| s.rrule Rule.hourly.count(3) }
-    expect(schedule.all_occurrences).to eq([t0, t0 + ONE_HOUR, t0 + 2*ONE_HOUR])
-  end
-
-  it "does not skip minutely rules with minute of hour over DST", :system_time_zone => "America/Denver" do
-    t0 = Time.local(2013, 11, 3, 1, 30, 0)
-    schedule = Schedule.new(t0) { |s| s.rrule Rule.hourly.count(3) }
-    schedule.rrule Rule.minutely.minute_of_hour([0, 15, 30, 45])
-    expect(schedule.first(5)).to eq([t0, t0 + 15*60, t0 + 30*60, t0 + 45*60, t0 + 60*60])
-  end
-
-  it "does not skip minutely rules with second of minute over DST", :system_time_zone => "America/Denver" do
-    t0 = Time.local(2013, 11, 3, 1, 30, 0)
-    schedule = Schedule.new(t0) { |s| s.rrule Rule.hourly.count(3) }
-    schedule.rrule Rule.minutely(15).second_of_minute(0)
-    expect(schedule.first(5)).to eq([t0, t0 + 15*60, t0 + 30*60, t0 + 45*60, t0 + 60*60])
-  end
-end
 end

--- a/spec/examples/dst_spec.rb
+++ b/spec/examples/dst_spec.rb
@@ -1,12 +1,13 @@
 require File.dirname(__FILE__) + '/../spec_helper'
 
-describe IceCube::Schedule do
+module IceCube
+describe Schedule do
 
   # DST in 2010 is March 14th at 2am
   it 'crosses a daylight savings time boundary with a recurrence rule in local time, by utc conversion' do
     start_time = Time.local(2010, 3, 13, 5, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.daily.count(20)
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.daily.count(20)
     dates = schedule.first(20)
     expect(dates.size).to eq(20)
     #check assumptions
@@ -19,8 +20,8 @@ describe IceCube::Schedule do
   # DST in 2010 is November 7th at 2am
   it 'crosses a daylight savings time boundary (in the other direction) with a recurrence rule in local time, by utc conversion' do
     start_time = Time.local(2010, 11, 6, 5, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.daily.count(20)
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.daily.count(20)
     dates = schedule.first(20)
     expect(dates.size).to eq(20)
     #check assumptions
@@ -32,10 +33,10 @@ describe IceCube::Schedule do
 
   it 'cross a daylight savings time boundary with a recurrence rule in local time' do
     start_time = Time.local(2010, 3, 14, 5, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.daily
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.daily
     # each occurrence MUST occur at 5pm, then we win
-    dates = schedule.occurrences(start_time + 20 * IceCube::ONE_DAY)
+    dates = schedule.occurrences(start_time + 20 * ONE_DAY)
     last = start_time
     dates.each do |date|
       expect(date.hour).to eq(5)
@@ -45,34 +46,34 @@ describe IceCube::Schedule do
 
   it 'every two hours over a daylight savings time boundary, checking interval' do
     start_time = Time.local(2010, 11, 6, 5, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.hourly(2)
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.hourly(2)
     dates = schedule.first(100)
     #check assumption
     distance_in_hours = 0
     dates.each do |d|
-      expect(d).to eq(start_time + IceCube::ONE_HOUR * distance_in_hours)
+      expect(d).to eq(start_time + ONE_HOUR * distance_in_hours)
       distance_in_hours += 2
     end
   end
 
   it 'every 30 minutes over a daylight savings time boundary, checking interval' do
     start_time = Time.local(2010, 11, 6, 23, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.minutely(30)
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.minutely(30)
     dates = schedule.first(100)
     #check assumption
     distance_in_minutes = 0
     dates.each do |d|
-      expect(d).to eq(start_time + IceCube::ONE_MINUTE * distance_in_minutes)
+      expect(d).to eq(start_time + ONE_MINUTE * distance_in_minutes)
       distance_in_minutes += 30
     end
   end
 
   it 'every 120 seconds over a daylight savings time boundary, checking interval' do
     start_time = Time.local(2010, 11, 6, 23, 50, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.secondly(120)
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.secondly(120)
     dates = schedule.first(10)
     #check assumption
     distance_in_seconds = 0
@@ -84,8 +85,8 @@ describe IceCube::Schedule do
 
   it 'every other day over a daylight savings time boundary, checking hour/min/sec' do
     start_time = Time.local(2010, 11, 6, 20, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.daily(2)
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.daily(2)
     dates = schedule.first(10)
     #check assumption
     dates.each do |d|
@@ -97,8 +98,8 @@ describe IceCube::Schedule do
 
   it 'every other month over a daylight savings time boundary, checking day/hour/min/sec' do
     start_time = Time.local(2010, 11, 6, 20, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.monthly(2)
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.monthly(2)
     dates = schedule.first(10)
     #check assumption
     dates.each do |d|
@@ -111,8 +112,8 @@ describe IceCube::Schedule do
 
   it 'every other year over a daylight savings time boundary, checking day/hour/min/sec' do
     start_time = Time.local(2010, 11, 6, 20, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.yearly(2)
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.yearly(2)
     dates = schedule.first(10)
     #check assumption
     dates.each do |d|
@@ -127,8 +128,8 @@ describe IceCube::Schedule do
   it 'LOCAL - has an until date on a rule that is over a DST from the start date' do
     start_time = Time.local(2010, 3, 13, 5, 0, 0)
     end_date = Time.local(2010, 3, 15, 5, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.daily.until(end_date)
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.daily.until(end_date)
     #make sure we end on the proper time
     expect(schedule.all_occurrences.last).to eq(end_date)
   end
@@ -136,8 +137,8 @@ describe IceCube::Schedule do
   it 'UTC - has an until date on a rule that is over a DST from the start date' do
     start_time = Time.utc(2010, 3, 13, 5, 0, 0)
     end_date = Time.utc(2010, 3, 15, 5, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.daily.until(end_date)
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.daily.until(end_date)
     #make sure we end on the proper time
     expect(schedule.all_occurrences.last).to eq(end_date)
   end
@@ -145,8 +146,8 @@ describe IceCube::Schedule do
   it 'LOCAL - has an until date on a rule that is over a DST from the start date (other direction)' do
     start_time = Time.local(2010, 11, 5, 5, 0, 0)
     end_date = Time.local(2010, 11, 10, 5, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.daily.until(end_date)
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.daily.until(end_date)
     #make sure we end on the proper time
     expect(schedule.all_occurrences.last).to eq(end_date)
   end
@@ -154,8 +155,8 @@ describe IceCube::Schedule do
   it 'UTC - has an until date on a rule that is over a DST from the start date (other direction)' do
     start_time = Time.utc(2010, 11, 5, 5, 0, 0)
     end_date = Time.utc(2010, 11, 10, 5, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.daily.until(end_date)
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.daily.until(end_date)
     #make sure we end on the proper time
     expect(schedule.all_occurrences.last).to eq(end_date)
   end
@@ -163,8 +164,8 @@ describe IceCube::Schedule do
   it 'LOCAL - has an end date on a rule that is over a DST from the start date' do
     start_time = Time.local(2010, 3, 13, 5, 0, 0)
     end_date = Time.local(2010, 3, 15, 5, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.daily
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.daily
     #make sure we end on the proper time
     expect(schedule.occurrences(end_date).last).to eq(end_date)
   end
@@ -172,8 +173,8 @@ describe IceCube::Schedule do
   it 'UTC - has an end date on a rule that is over a DST from the start date' do
     start_time = Time.utc(2010, 3, 13, 5, 0, 0)
     end_date = Time.utc(2010, 3, 15, 5, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.daily
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.daily
     #make sure we end on the proper time
     expect(schedule.occurrences(end_date).last).to eq(end_date)
   end
@@ -181,8 +182,8 @@ describe IceCube::Schedule do
   it 'LOCAL - has an end date on a rule that is over a DST from the start date (other direction)' do
     start_time = Time.local(2010, 11, 5, 5, 0, 0)
     end_date = Time.local(2010, 11, 10, 5, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.daily
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.daily
     #make sure we end on the proper time
     expect(schedule.occurrences(end_date).last).to eq(end_date)
   end
@@ -190,31 +191,31 @@ describe IceCube::Schedule do
   it 'UTC - has an end date on a rule that is over a DST from the start date (other direction)' do
     start_time = Time.utc(2010, 11, 5, 5, 0, 0)
     end_date = Time.utc(2010, 11, 10, 5, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.daily
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.daily
     #make sure we end on the proper time
     expect(schedule.occurrences(end_date).last).to eq(end_date)
   end
 
   it 'local - should make dates on interval over dst - github issue 4' do
     start_time = Time.local(2010, 3, 12, 19, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.daily(3)
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.daily(3)
     expect(schedule.first(3)).to eq([Time.local(2010, 3, 12, 19, 0, 0), Time.local(2010, 3, 15, 19, 0, 0), Time.local(2010, 3, 18, 19, 0, 0)])
   end
 
   it 'local - should make dates on monthly interval over dst - github issue 4' do
     start_time = Time.local(2010, 3, 12, 19, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.monthly(2)
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.monthly(2)
     expect(schedule.first(6)).to eq([Time.local(2010, 3, 12, 19, 0, 0), Time.local(2010, 5, 12, 19, 0, 0), Time.local(2010, 7, 12, 19, 0, 0),
                                  Time.local(2010, 9, 12, 19, 0, 0), Time.local(2010, 11, 12, 19, 0, 0), Time.local(2011, 1, 12, 19, 0, 0)])
   end
 
   it 'local - should make dates on monthly interval over dst - github issue 4' do
     start_time = Time.local(2010, 3, 12, 19, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.monthly
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.monthly
     expect(schedule.first(10)).to eq([Time.local(2010, 3, 12, 19, 0, 0), Time.local(2010, 4, 12, 19, 0, 0), Time.local(2010, 5, 12, 19, 0, 0),
                                   Time.local(2010, 6, 12, 19, 0, 0), Time.local(2010, 7, 12, 19, 0, 0), Time.local(2010, 8, 12, 19, 0, 0),
                                   Time.local(2010, 9, 12, 19, 0, 0), Time.local(2010, 10, 12, 19, 0, 0), Time.local(2010, 11, 12, 19, 0, 0),
@@ -223,78 +224,76 @@ describe IceCube::Schedule do
 
   it 'local - should make dates on yearly interval over dst - github issue 4' do
     start_time = Time.local(2010, 3, 12, 19, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.yearly(2)
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.yearly(2)
     expect(schedule.first(3)).to eq([Time.local(2010, 3, 12, 19, 0, 0), Time.local(2012, 3, 12, 19, 0, 0), Time.local(2014, 3, 12, 19, 0, 0)])
   end
 
   it "local - should make dates on monthly (day of week) inverval over dst - github issue 5" do
     start_time = Time.local(2010, 3, 7, 12, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.monthly.day_of_week(:sunday => [1])
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.monthly.day_of_week(:sunday => [1])
     expect(schedule.first(3)).to eq([Time.local(2010, 3, 7, 12, 0, 0), Time.local(2010, 4, 4, 12, 0, 0), Time.local(2010, 5, 2, 12, 0, 0)])
   end
 
   it "local - should make dates on monthly (day of month) inverval over dst - github issue 5" do
     start_time = Time.local(2010, 3, 1, 12, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.monthly.day_of_month(1)
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.monthly.day_of_month(1)
     expect(schedule.first(3)).to eq([Time.local(2010, 3, 1, 12, 0, 0), Time.local(2010, 4, 1, 12, 0, 0), Time.local(2010, 5, 1, 12, 0, 0)])
   end
 
   it "local - should make dates on weekly (day) inverval over dst - github issue 5" do
     start_time = Time.local(2010, 3, 7, 12, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.weekly.day(:sunday)
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.weekly.day(:sunday)
     expect(schedule.first(3)).to eq([Time.local(2010, 3, 7, 12, 0, 0), Time.local(2010, 3, 14, 12, 0, 0), Time.local(2010, 3, 21, 12, 0, 0)])
   end
 
   it "local - should make dates on monthly (day of year) inverval over dst - github issue 5" do
     start_time = Time.local(2010, 3, 7, 12, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.monthly.day_of_year(1)
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.monthly.day_of_year(1)
     expect(schedule.first(3)).to eq([Time.local(2011, 1, 1, 12, 0, 0), Time.local(2012, 1, 1, 12, 0, 0), Time.local(2013, 1, 1, 12, 0, 0)])
   end
 
   it "local - should make dates on monthly (month_of_year) inverval over dst - github issue 5" do
     start_time = Time.local(2010, 3, 7, 12, 0, 0)
-    schedule = IceCube::Schedule.new(start_time)
-    schedule.add_recurrence_rule IceCube::Rule.yearly.month_of_year(:april).day_of_month(10)
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule Rule.yearly.month_of_year(:april).day_of_month(10)
     expect(schedule.first(3)).to eq([Time.local(2010, 4, 10, 12, 0, 0), Time.local(2011, 4, 10, 12, 0, 0), Time.local(2012, 4, 10, 12, 0, 0)])
   end
 
   it "skips double daily occurrences from end of DST", :system_time_zone => "America/Denver" do
     t0 = Time.local(2013, 11, 3, 1, 30, 0)
-    schedule = IceCube::Schedule.new(t0) { |s| s.rrule IceCube::Rule.daily.count(3) }
+    schedule = Schedule.new(t0) { |s| s.rrule Rule.daily.count(3) }
     expect(schedule.all_occurrences).to eq([t0, Time.local(2013, 11, 4, 1, 30, 0), Time.local(2013, 11, 5, 1, 30, 0)])
   end
 
   it "skips double monthly occurrences from end of DST", :system_time_zone => "America/Nome" do
     t0 = Time.local(2017, 10, 5, 1, 0, 0)
-    schedule = IceCube::Schedule.new(t0) { |s| s.rrule IceCube::Rule.monthly.day_of_month(5).count(3) }
-    expect(schedule.all_occurrences).to eq([t0, t0 + 31*IceCube::ONE_DAY + IceCube::ONE_HOUR, t0 + 61*IceCube::ONE_DAY + IceCube::ONE_HOUR])
+    schedule = Schedule.new(t0) { |s| s.rrule Rule.monthly.day_of_month(5).count(3) }
+    expect(schedule.all_occurrences).to eq([t0, t0 + 31*ONE_DAY + ONE_HOUR, t0 + 61*ONE_DAY + ONE_HOUR])
   end
 
   it "does not skip hourly rules over DST", :system_time_zone => "America/Denver" do
     t0 = Time.local(2013, 11, 3, 1, 30, 0)
-    schedule = IceCube::Schedule.new(t0) { |s| s.rrule IceCube::Rule.hourly.count(3) }
+    schedule = Schedule.new(t0) { |s| s.rrule Rule.hourly.count(3) }
     expect(schedule.all_occurrences).to eq([t0, t0 + ONE_HOUR, t0 + 2*ONE_HOUR])
   end
 
   it "does not skip minutely rules with minute of hour over DST", :system_time_zone => "America/Denver" do
     t0 = Time.local(2013, 11, 3, 1, 30, 0)
-    schedule = IceCube::Schedule.new(t0) { |s| s.rrule IceCube::Rule.hourly.count(3) }
-    schedule.rrule IceCube::Rule.minutely.minute_of_hour([0, 15, 30, 45])
+    schedule = Schedule.new(t0) { |s| s.rrule Rule.hourly.count(3) }
+    schedule.rrule Rule.minutely.minute_of_hour([0, 15, 30, 45])
     expect(schedule.first(5)).to eq([t0, t0 + 15*60, t0 + 30*60, t0 + 45*60, t0 + 60*60])
   end
 
   it "does not skip minutely rules with second of minute over DST", :system_time_zone => "America/Denver" do
     t0 = Time.local(2013, 11, 3, 1, 30, 0)
-    schedule = IceCube::Schedule.new(t0) { |s| s.rrule IceCube::Rule.hourly.count(3) }
-    schedule.rrule IceCube::Rule.minutely(15).second_of_minute(0)
+    schedule = Schedule.new(t0) { |s| s.rrule Rule.hourly.count(3) }
+    schedule.rrule Rule.minutely(15).second_of_minute(0)
     expect(schedule.first(5)).to eq([t0, t0 + 15*60, t0 + 30*60, t0 + 45*60, t0 + 60*60])
   end
-
-
-
+end
 end

--- a/spec/examples/dst_spec.rb
+++ b/spec/examples/dst_spec.rb
@@ -270,6 +270,12 @@ describe IceCube::Schedule do
     expect(schedule.all_occurrences).to eq([t0, t0 + 25*ONE_HOUR, t0 + 49*ONE_HOUR])
   end
 
+  it "skips double monthly occurrences from end of DST", :system_time_zone => "America/Nome" do
+    t0 = Time.local(2017, 10, 5, 1, 0, 0)
+    schedule = IceCube::Schedule.new(t0) { |s| s.rrule IceCube::Rule.monthly.day_of_month(5).count(3) }
+    expect(schedule.all_occurrences).to eq([t0, t0 + 31*IceCube::ONE_DAY + IceCube::ONE_HOUR, t0 + 61*IceCube::ONE_DAY + IceCube::ONE_HOUR])
+  end
+
   it "does not skip hourly rules over DST" do
     Time.zone = "America/Denver"
     t0 = Time.zone.parse("Sun, 03 Nov 2013 01:30:00 MDT -06:00")


### PR DESCRIPTION
Simplify the method we use for calculating time changes across DST boundaries by
performing arithmetic under UTC to get "absolute" values. This is a revert of
the "unrolling in pairs" method introduced in c93fa7e for fixing #189.

The method of converting to UTC and back for doing time arithmetic only applies
when DST needs to be taken into consideration. For rules with less than daily
intervals, both hours still need to occur. This distinction was added in the
original fix.

However, the method was not correctly tested for non-ActiveSupport times (local
system TZ) and the advancing of time to the next occurrence was validating both
the last DT hour (before fall back) and first ST hour (after fall back) causing
double occurrences for the "same" hour on the clock face.