### PR TITLE
Full Timezone support when parsing ical

### DIFF
--- a/ice_cube.gemspec
+++ b/ice_cube.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec', '> 3')
+  s.add_development_dependency('timecop')
 end

--- a/lib/ice_cube/builders/ical_builder.rb
+++ b/lib/ice_cube/builders/ical_builder.rb
@@ -38,9 +38,9 @@ module IceCube
     def self.ical_format(time, force_utc)
       time = time.dup.utc if force_utc
       if time.utc?
-        ":#{IceCube::I18n.l(time, format: '%Y%m%dT%H%M%SZ')}" # utc time
+        ":#{IceCube::I18n.l(time.utc, format: '%Y%m%dT%H%M%SZ')}" # utc time
       else
-        ";TZID=#{IceCube::I18n.l(time, format: '%Z:%Y%m%dT%H%M%S')}" # local time specified
+        ";TZID=#{time.time_zone.name}:#{IceCube::I18n.l(time, format: '%Y%m%dT%H%M%S')}" # local time specified
       end
     end
 

--- a/lib/ice_cube/parsers/ical_parser.rb
+++ b/lib/ice_cube/parsers/ical_parser.rb
@@ -1,83 +1,102 @@
 module IceCube
   class IcalParser
-    def self.schedule_from_ical(ical_string, options = {})
-      data = {}
-      ical_string.each_line do |line|
-        (property, value) = line.split(':')
-        (property, tzid) = property.split(';')
-        case property
-        when 'DTSTART'
-          data[:start_time] = Time.parse(value)
-        when 'DTEND'
-          data[:end_time] = Time.parse(value)
-        when 'EXDATE'
-          data[:extimes] ||= []
-          data[:extimes] += value.split(',').map{|v| Time.parse(v)}
-        when 'DURATION'
-          data[:duration] # FIXME
-        when 'RRULE'
-          data[:rrules] ||= []
-          data[:rrules] += [rule_from_ical(value)]
-        end
-      end
-      Schedule.from_hash data
-    end
-
-    def self.rule_from_ical(ical)
-      raise ArgumentError, 'empty ical rule' if ical.nil?
-
-      validations = {}
-      params = {validations: validations, interval: 1}
-
-      ical.split(';').each do |rule|
-        (name, value) = rule.split('=')
-        raise ArgumentError, "Invalid iCal rule component" if value.nil?
-        value.strip!
-        case name
-        when 'FREQ'
-          params[:rule_type] = "IceCube::#{value[0]}#{value.downcase[1..-1]}Rule"
-        when 'INTERVAL'
-          params[:interval] = value.to_i
-        when 'COUNT'
-          params[:count] = value.to_i
-        when 'UNTIL'
-          params[:until] = Time.parse(value).utc
-        when 'WKST'
-          params[:week_start] = TimeUtil.ical_day_to_symbol(value)
-        when 'BYSECOND'
-          validations[:second_of_minute] = value.split(',').map(&:to_i)
-        when 'BYMINUTE'
-          validations[:minute_of_hour] = value.split(',').map(&:to_i)
-        when 'BYHOUR'
-          validations[:hour_of_day] = value.split(',').map(&:to_i)
-        when 'BYDAY'
-          dows = {}
-          days = []
-          value.split(',').each do |expr|
-            day = TimeUtil.ical_day_to_symbol(expr.strip[-2..-1])
-            if expr.strip.length > 2  # day with occurence
-              occ = expr[0..-3].to_i
-              dows[day].nil? ? dows[day] = [occ] : dows[day].push(occ)
-              days.delete(TimeUtil.sym_to_wday(day))
-            else
-              days.push TimeUtil.sym_to_wday(day) if dows[day].nil?
+    class << self
+      def schedule_from_ical(ical_string, options = {})
+        data = {}
+        ical_string.each_line do |line|
+          (property, value) = line.split(':')
+          (property, tzid) = property.split(';')
+          case property
+          when 'DTSTART'
+            data[:start_time] = parse_in_tzid(value, tzid)
+          when 'DTEND'
+            data[:end_time] = parse_in_tzid(value, tzid)
+          when 'RDATE'
+            date[:rtimes] ||= []
+            data[:rtimes] += value.split(',').map do |v|
+              parse_in_tzid(v, tzid)
             end
+          when 'EXDATE'
+            data[:extimes] ||= []
+            data[:extimes] += value.split(',').map do |v|
+              parse_in_tzid(v, tzid)
+            end
+          when 'DURATION'
+            data[:duration] # FIXME
+          when 'RRULE'
+            data[:rrules] ||= []
+            data[:rrules] += [rule_from_ical(value)]
           end
-          validations[:day_of_week] = dows unless dows.empty?
-          validations[:day] = days unless days.empty?
-        when 'BYMONTHDAY'
-          validations[:day_of_month] = value.split(',').map(&:to_i)
-        when 'BYMONTH'
-          validations[:month_of_year] = value.split(',').map(&:to_i)
-        when 'BYYEARDAY'
-          validations[:day_of_year] = value.split(',').map(&:to_i)
-        when 'BYSETPOS'
-        else
-          validations[name] = nil # invalid type
         end
+        Schedule.from_hash data
       end
 
-      Rule.from_hash(params)
+      def rule_from_ical(ical)
+        raise ArgumentError, 'empty ical rule' if ical.nil?
+
+        validations = {}
+        params = {validations: validations, interval: 1}
+
+        ical.split(';').each do |rule|
+          (name, value) = rule.split('=')
+          raise ArgumentError, "Invalid iCal rule component" if value.nil?
+          value.strip!
+          case name
+          when 'FREQ'
+            params[:rule_type] = "IceCube::#{value[0]}#{value.downcase[1..-1]}Rule"
+          when 'INTERVAL'
+            params[:interval] = value.to_i
+          when 'COUNT'
+            params[:count] = value.to_i
+          when 'UNTIL'
+            params[:until] = Time.parse(value).utc
+          when 'WKST'
+            params[:week_start] = TimeUtil.ical_day_to_symbol(value)
+          when 'BYSECOND'
+            validations[:second_of_minute] = value.split(',').map(&:to_i)
+          when 'BYMINUTE'
+            validations[:minute_of_hour] = value.split(',').map(&:to_i)
+          when 'BYHOUR'
+            validations[:hour_of_day] = value.split(',').map(&:to_i)
+          when 'BYDAY'
+            dows = {}
+            days = []
+            value.split(',').each do |expr|
+              day = TimeUtil.ical_day_to_symbol(expr.strip[-2..-1])
+              if expr.strip.length > 2  # day with occurence
+                occ = expr[0..-3].to_i
+                dows[day].nil? ? dows[day] = [occ] : dows[day].push(occ)
+                days.delete(TimeUtil.sym_to_wday(day))
+              else
+                days.push TimeUtil.sym_to_wday(day) if dows[day].nil?
+              end
+            end
+            validations[:day_of_week] = dows unless dows.empty?
+            validations[:day] = days unless days.empty?
+          when 'BYMONTHDAY'
+            validations[:day_of_month] = value.split(',').map(&:to_i)
+          when 'BYMONTH'
+            validations[:month_of_year] = value.split(',').map(&:to_i)
+          when 'BYYEARDAY'
+            validations[:day_of_year] = value.split(',').map(&:to_i)
+          when 'BYSETPOS'
+          else
+            validations[name] = nil # invalid type
+          end
+        end
+
+        Rule.from_hash(params)
+      end
+
+      private
+
+      def parse_in_tzid(value, tzid)
+        time_parser = Time
+        if tzid
+          time_parser = ActiveSupport::TimeZone.new(tzid.split('=')[1]) || Time
+        end
+        time_parser.parse(value)
+      end
     end
   end
 end

--- a/spec/examples/hourly_rule_spec.rb
+++ b/spec/examples/hourly_rule_spec.rb
@@ -39,14 +39,15 @@ module IceCube
       end
 
       it 'should not skip times in DST end hour' do
-        schedule = Schedule.new(t0 = Time.local(2013, 11, 3, 0, 0, 0))
+        tz = ActiveSupport::TimeZone["America/Vancouver"]
+        schedule = Schedule.new(t0 = tz.local(2013, 11, 3, 0, 0, 0))
         schedule.add_recurrence_rule Rule.hourly
-        expect(schedule.first(4)).to eq([
-          Time.local(2013, 11, 3, 0, 0, 0),             # -0700
-          Time.local(2013, 11, 3, 1, 0, 0) - ONE_HOUR,  # -0700
-          Time.local(2013, 11, 3, 1, 0, 0),             # -0800
-          Time.local(2013, 11, 3, 2, 0, 0),             # -0800
-        ])
+        expect(schedule.first(4)).to eq [
+          tz.local(2013, 11, 3, 0, 0, 0),             # -0700
+          tz.local(2013, 11, 3, 1, 0, 0),             # -0700
+          tz.local(2013, 11, 3, 2, 0, 0) - ONE_HOUR,  # -0800
+          tz.local(2013, 11, 3, 2, 0, 0),             # -0800
+        ]
       end
 
     end

--- a/spec/examples/recur_spec.rb
+++ b/spec/examples/recur_spec.rb
@@ -1,4 +1,5 @@
 require File.dirname(__FILE__) + '/../spec_helper'
+require 'timecop'
 
 include IceCube
 
@@ -115,6 +116,18 @@ describe :next_occurrence do
     expect(schedule.next_occurrence(schedule.start_time)).to eq(schedule.start_time + 30 * ONE_MINUTE)
   end
 
+  it 'should get the next occurrence across the daylight savings time boundary' do
+    # 2016 daylight savings time cutoff is Sunday March 13
+    # Time.zone = 'America/New_York'
+    start_time = Time.zone.local(2016, 3, 13, 0, 0, 0)
+    expected_next_time = Time.zone.local(2016, 3, 13, 5, 0, 0)
+    schedule = Schedule.new(start_time)
+    schedule.add_recurrence_rule(Rule.hourly(interval=4))
+
+    Timecop.freeze(start_time) do
+      expect(schedule.next_occurrence(schedule.start_time)).to eq expected_next_time
+    end
+  end
 end
 
 describe :next_occurrences do

--- a/spec/examples/to_ical_spec.rb
+++ b/spec/examples/to_ical_spec.rb
@@ -94,10 +94,16 @@ describe IceCube, 'to_ical' do
     ].include?(rule.to_ical)).to be_truthy
   end
 
-  it 'should be able to serialize a base schedule to ical in local time' do
+  it 'should be able to serialize a base schedule to ical in local time, using a US timezone' do
     Time.zone = "Eastern Time (US & Canada)"
     schedule = IceCube::Schedule.new(Time.zone.local(2010, 5, 10, 9, 0, 0))
-    expect(schedule.to_ical).to eq("DTSTART;TZID=EDT:20100510T090000")
+    expect(schedule.to_ical).to eq("DTSTART;TZID=Eastern Time (US & Canada):20100510T090000")
+  end
+
+  it 'should be able to serialize a base schedule to ical in local time, using an Olson timezone' do
+    Time.zone = "America/New_York"
+    schedule = IceCube::Schedule.new(Time.zone.local(2010, 5, 10, 9, 0, 0))
+    expect(schedule.to_ical).to eq "DTSTART;TZID=America/New_York:20100510T090000"
   end
 
   it 'should be able to serialize a base schedule to ical in UTC time' do
@@ -110,7 +116,7 @@ describe IceCube, 'to_ical' do
     schedule = IceCube::Schedule.new(Time.zone.local(2010, 5, 10, 9, 0, 0))
     schedule.add_recurrence_rule IceCube::Rule.weekly
     # test equality
-    expectation = "DTSTART;TZID=PDT:20100510T090000\n"
+    expectation = "DTSTART;TZID=Pacific Time (US & Canada):20100510T090000\n"
     expectation << 'RRULE:FREQ=WEEKLY'
     expect(schedule.to_ical).to eq(expectation)
   end
@@ -120,7 +126,7 @@ describe IceCube, 'to_ical' do
     schedule = IceCube::Schedule.new(Time.zone.local(2010, 10, 20, 4, 30, 0))
     schedule.add_recurrence_rule IceCube::Rule.weekly.day_of_week(:monday => [2, -1])
     schedule.add_recurrence_rule IceCube::Rule.hourly
-    expectation = "DTSTART;TZID=EDT:20101020T043000\n"
+    expectation = "DTSTART;TZID=Eastern Time (US & Canada):20101020T043000\n"
     expectation << "RRULE:FREQ=WEEKLY;BYDAY=2MO,-1MO\n"
     expectation << "RRULE:FREQ=HOURLY"
     expect(schedule.to_ical).to eq(expectation)
@@ -131,17 +137,17 @@ describe IceCube, 'to_ical' do
     schedule = IceCube::Schedule.new(Time.zone.local(2010, 5, 10, 9, 0, 0))
     schedule.add_exception_rule IceCube::Rule.weekly
     # test equality
-    expectation= "DTSTART;TZID=PDT:20100510T090000\n"
+    expectation= "DTSTART;TZID=Pacific Time (US & Canada):20100510T090000\n"
     expectation<< 'EXRULE:FREQ=WEEKLY'
     expect(schedule.to_ical).to eq(expectation)
   end
 
   it 'should be able to serialize a schedule with multiple exrules' do
-    Time.zone ='Eastern Time (US & Canada)'
+    Time.zone ='America/New_York'
     schedule = IceCube::Schedule.new(Time.zone.local(2010, 10, 20, 4, 30, 0))
     schedule.add_exception_rule IceCube::Rule.weekly.day_of_week(:monday => [2, -1])
     schedule.add_exception_rule IceCube::Rule.hourly
-    expectation = "DTSTART;TZID=EDT:20101020T043000\n"
+    expectation = "DTSTART;TZID=America/New_York:20101020T043000\n"
     expectation<< "EXRULE:FREQ=WEEKLY;BYDAY=2MO,-1MO\n"
     expectation<< "EXRULE:FREQ=HOURLY"
     expect(schedule.to_ical).to eq(expectation)
@@ -211,6 +217,25 @@ describe IceCube, 'to_ical' do
     expect(schedule.to_ical).to eq("DTSTART;TZID=#{time.zone}:#{time.strftime('%Y%m%dT%H%M%S')}") # default false
     expect(schedule.to_ical(false)).to eq("DTSTART;TZID=#{time.zone}:#{time.strftime('%Y%m%dT%H%M%S')}")
     expect(schedule.to_ical(true)).to  eq("DTSTART:#{time.utc.strftime('%Y%m%dT%H%M%S')}Z")
+  end
+
+  it 'displays an ActiveSupport::TimeWithZone at utc time as Z' do
+    time = Time.now.utc
+    schedule = IceCube::Schedule.new(time)
+    expect(schedule.to_ical(false)).to eq "DTSTART:#{time.strftime('%Y%m%dT%H%M%S')}Z"
+  end
+
+  it 'displays an ActiveSupport::TimeWithZone to utc when using force_utc' do
+    # this is 8am in NY, 12pm UTC (UTC -4 in summer)
+    time = Time.new(2016, 5, 9, 12, 0, 0, 0).in_time_zone('America/New_York')
+    schedule = IceCube::Schedule.new(time)
+    expect(schedule.to_ical(true)).to eq "DTSTART:20160509T120000Z"
+  end
+
+  it 'displays a Time utc time as Z' do
+    time = Time.now.utc
+    schedule = IceCube::Schedule.new(time)
+    expect(schedule.to_ical(true)).to eq "DTSTART:#{time.strftime('%Y%m%dT%H%M%S')}Z"
   end
 
   it 'should be able to serialize to ical with an until date' do


### PR DESCRIPTION
This PR builds on the great work from #335 (thanks @dcosson)

I'll be removing the need for `ActiveSupport` here.

Also, added support for parsing `RDATE` while I'm in here.