### PR TITLE
Fix warnings

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
---format documentation
---color
+--require spec_helper

--- a/ice_cube.gemspec
+++ b/ice_cube.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.test_files    = Dir.glob('spec/*.rb')
   s.require_paths = ['lib']
   s.has_rdoc      = true
-  s.rubyforge_project = "ice-cube"
 
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec', '> 3')

--- a/lib/ice_cube.rb
+++ b/lib/ice_cube.rb
@@ -1,8 +1,5 @@
 require 'date'
 require 'ice_cube/deprecated'
-require 'ice_cube/i18n'
-
-IceCube::I18n.detect_backend!
 
 module IceCube
 
@@ -10,6 +7,7 @@ module IceCube
 
   autoload :TimeUtil, 'ice_cube/time_util'
   autoload :FlexibleHash, 'ice_cube/flexible_hash'
+  autoload :I18n, 'ice_cube/i18n'
 
   autoload :Rule, 'ice_cube/rule'
   autoload :Schedule, 'ice_cube/schedule'

--- a/lib/ice_cube/i18n.rb
+++ b/lib/ice_cube/i18n.rb
@@ -1,5 +1,10 @@
+require 'ice_cube/null_i18n'
+
 module IceCube
   module I18n
+
+    LOCALES_PATH = File.expand_path(File.join('..', '..', '..', 'config', 'locales'), __FILE__)
+
     def self.t(*args)
       backend.t(*args)
     end
@@ -9,16 +14,14 @@ module IceCube
     end
 
     def self.backend
-      @backend
+      @backend ||= detect_backend!
     end
 
     def self.detect_backend!
-      require 'i18n'
-      ::I18n.load_path += Dir[File.expand_path('../../../config/locales/*{rb,yml}', __FILE__)]
-      @backend = ::I18n
-    rescue LoadError
-      require 'ice_cube/null_i18n'
-      @backend = NullI18n
+      ::I18n.load_path += Dir[File.join(LOCALES_PATH, '*.yml')]
+      ::I18n
+    rescue NameError
+      NullI18n
     end
   end
 end

--- a/lib/ice_cube/null_i18n.rb
+++ b/lib/ice_cube/null_i18n.rb
@@ -7,13 +7,19 @@ module IceCube
 
       base = base[options[:count] == 1 ? "one" : "other"] if options[:count]
 
-      if base.is_a?(Hash)
-        return base.each_with_object({}) do |(key, value), hash|
-          hash[key.is_a?(String) ? key.to_sym : key] = value
+      case base
+      when Hash
+        base.each_with_object({}) do |(k, v), hash|
+          hash[k.is_a?(String) ? k.to_sym : k] = v
         end
+      when Array
+        base.each_with_index.each_with_object({}) do |(v, k), hash|
+          hash[k] = v
+        end
+      else
+        return base unless base.include?('%{')
+        base % options
       end
-
-      options.reduce(base) { |result, (find, replace)| result.gsub("%{#{find}}", "#{replace}") }
     end
 
     def self.l(date_or_time, options = {})

--- a/lib/ice_cube/null_i18n.rb
+++ b/lib/ice_cube/null_i18n.rb
@@ -22,7 +22,7 @@ module IceCube
     end
 
     def self.config
-      @config ||= YAML.load(File.read(File.join(File.dirname(__FILE__), '..', '..', 'config', 'locales', 'en.yml')))['en']
+      @config ||= YAML.load_file(File.join(IceCube::I18n::LOCALES_PATH, 'en.yml'))['en']
     end
   end
 end

--- a/lib/ice_cube/occurrence.rb
+++ b/lib/ice_cube/occurrence.rb
@@ -19,6 +19,7 @@ module IceCube
   #     Time.now - Occurrence.new(start_time) # => 3600
   #
   class Occurrence < SimpleDelegator
+    include Comparable
 
     # Report class name as 'Time' to thwart type checking.
     def self.name
@@ -41,10 +42,6 @@ module IceCube
 
     def <=>(other)
       @start_time <=> other
-    end
-
-    def ==(other)
-      @start_time == other
     end
 
     def each(&block)

--- a/lib/ice_cube/occurrence.rb
+++ b/lib/ice_cube/occurrence.rb
@@ -49,23 +49,15 @@ module IceCube
     end
     alias_method :kind_of?, :is_a?
 
-    def intersects? other
-      if other.is_a?(Occurrence) || other.is_a?(Range)
-        lower_bound_1 = first + 1
-        upper_bound_1 = last # exclude end
-        lower_bound_2 = other.first + 1
-        upper_bound_2 = other.last + 1
-        if (lower_bound_2 <=> upper_bound_2) > 0
-          false
-        elsif (lower_bound_1 <=> upper_bound_1) > 0
-          false
-        else
-          (upper_bound_1 <=> lower_bound_2) >= 0 and
-            (upper_bound_2 <=> lower_bound_1) >= 0
-        end
-      else
-        cover? other
-      end
+    def intersects?(other)
+      return cover?(other) unless other.is_a?(Occurrence) || other.is_a?(Range)
+
+      this_start  = first + 1
+      this_end    = last # exclude end boundary
+      other_start = other.first + 1
+      other_end   = other.last + 1
+
+      !(this_end < other_start || this_start > other_end)
     end
 
     def cover?(other)

--- a/lib/ice_cube/occurrence.rb
+++ b/lib/ice_cube/occurrence.rb
@@ -1,4 +1,3 @@
-require 'forwardable'
 require 'delegate'
 
 module IceCube
@@ -26,17 +25,30 @@ module IceCube
       'Time'
     end
 
-    # Optimize for common methods to avoid method_missing
-    extend Forwardable
-    def_delegators :start_time, :to_i, :<=>, :==
-    def_delegators :to_range, :cover?, :include?, :each, :first, :last
-
     attr_reader :start_time, :end_time
+    alias first start_time
+    alias last end_time
 
     def initialize(start_time, end_time=nil)
       @start_time = start_time
       @end_time = end_time || start_time
       __setobj__ @start_time
+    end
+
+    def to_i
+      @start_time.to_i
+    end
+
+    def <=>(other)
+      @start_time <=> other
+    end
+
+    def ==(other)
+      @start_time == other
+    end
+
+    def each(&block)
+      to_range.each(&block)
     end
 
     def is_a?(klass)
@@ -62,6 +74,11 @@ module IceCube
         cover? other
       end
     end
+
+    def cover?(other)
+      to_range.cover?(other)
+    end
+    alias_method :include?, :cover?
 
     def comparable_time
       start_time

--- a/lib/ice_cube/occurrence.rb
+++ b/lib/ice_cube/occurrence.rb
@@ -44,10 +44,6 @@ module IceCube
       @start_time <=> other
     end
 
-    def each(&block)
-      to_range.each(&block)
-    end
-
     def is_a?(klass)
       klass == ::Time || super
     end

--- a/lib/ice_cube/rule.rb
+++ b/lib/ice_cube/rule.rb
@@ -58,11 +58,6 @@ module IceCube
       next_time(time, schedule, time).to_i == time.to_i
     end
 
-    # Whether this rule requires a full run
-    def full_required?
-      !@count.nil?
-    end
-
     class << self
 
       # Convert from a hash and create a rule

--- a/lib/ice_cube/rule.rb
+++ b/lib/ice_cube/rule.rb
@@ -19,11 +19,9 @@ module IceCube
       until_time || occurrence_count
     end
 
-    def ==(rule)
-      if rule.is_a? Rule
-        hash = to_hash
-        hash && hash == rule.to_hash
-      end
+    def ==(other)
+      return false unless other.is_a? Rule
+      hash == other.hash
     end
 
     def hash

--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -340,9 +340,9 @@ module IceCube
       IcalParser.schedule_from_ical(ical, options)
     end
 
-    # Convert the schedule to yaml
-    def to_yaml(*args)
-      YAML::dump(to_hash, *args)
+    # Hook for YAML.dump, enables to_yaml
+    def encode_with(coder)
+      coder.represent_object nil, to_hash
     end
 
     # Load the schedule from yaml

--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -446,12 +446,12 @@ module IceCube
     # Get the next time after (or including) a specific time
     def next_time(time, closing_time)
       loop do
-        min_time = recurrence_rules_with_implicit_start_occurrence.reduce(nil) do |min_time, rule|
+        min_time = recurrence_rules_with_implicit_start_occurrence.reduce(nil) do |best_time, rule|
           begin
-            new_time = rule.next_time(time, start_time, min_time || closing_time)
-            [min_time, new_time].compact.min
+            new_time = rule.next_time(time, start_time, best_time || closing_time)
+            [best_time, new_time].compact.min
           rescue StopIteration
-            min_time
+            best_time
           end
         end
         break unless min_time

--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -371,6 +371,7 @@ module IceCube
       end
       data
     end
+    alias_method :to_h, :to_hash
 
     # Load the schedule from a hash
     def self.from_hash(original_hash, options = {})

--- a/lib/ice_cube/schedule.rb
+++ b/lib/ice_cube/schedule.rb
@@ -384,7 +384,7 @@ module IceCube
     # Determine if the schedule will end
     # @return [Boolean] true if ending, false if repeating forever
     def terminating?
-      recurrence_rules.empty? || recurrence_rules.all?(&:terminating?)
+      @all_recurrence_rules.all?(&:terminating?)
     end
 
     def hash

--- a/lib/ice_cube/single_occurrence_rule.rb
+++ b/lib/ice_cube/single_occurrence_rule.rb
@@ -23,6 +23,10 @@ module IceCube
       { :time => time }
     end
 
+    def full_required?
+      false
+    end
+
   end
 
 end

--- a/lib/ice_cube/time_util.rb
+++ b/lib/ice_cube/time_util.rb
@@ -170,7 +170,7 @@ module IceCube
 
     # Convert wday number to day symbol
     def self.wday_to_sym(wday)
-      return sym = wday if DAYS.keys.include? wday
+      return wday if DAYS.keys.include? wday
       DAYS.invert.fetch(wday) do |i|
         raise ArgumentError, "Expecting Integer value for weekday. " \
                              "No such wday number: #{i.inspect}"

--- a/lib/ice_cube/time_util.rb
+++ b/lib/ice_cube/time_util.rb
@@ -177,13 +177,6 @@ module IceCube
       end
     end
 
-    # Convert a symbol to an ical day (SU, MO)
-    def self.week_start(sym)
-      raise ArgumentError, "Invalid day: #{str}" unless DAYS.keys.include?(sym)
-      day = sym.to_s.upcase[0..1]
-      day
-    end
-
     # Convert weekday from base sunday to the schedule's week start.
     def self.normalize_wday(wday, week_start)
       (wday - sym_to_wday(week_start)) % 7
@@ -258,10 +251,6 @@ module IceCube
       if time.dst? ^ one_hour_ago.dst?
         (time.utc_offset - one_hour_ago.utc_offset) / ONE_HOUR
       end
-    end
-
-    def self.same_clock?(t1, t2)
-      CLOCK_VALUES.all? { |i| t1.send(i) == t2.send(i) }
     end
 
     # Handle discrepancies between various time types
@@ -348,10 +337,6 @@ module IceCube
           @time -= TimeUtil.days_in_month(@time) * ONE_DAY
         end
         @time += ONE_DAY
-      end
-
-      def clear_year
-        @time
       end
 
     end

--- a/lib/ice_cube/validated_rule.rb
+++ b/lib/ice_cube/validated_rule.rb
@@ -51,10 +51,6 @@ module IceCube
       Array(@validations[base_interval_validation.type])
     end
 
-    def base_interval_type
-      base_interval_validation.type
-    end
-
     # Compute the next time after (or including) the specified time in respect
     # to the given start time
     def next_time(time, start_time, closing_time)
@@ -72,14 +68,6 @@ module IceCube
 
     def realign(opening_time, start_time)
       start_time
-    end
-
-    def skipped_for_dst
-      @uses -= 1 if @uses > 0
-    end
-
-    def dst_adjust?
-      @validations[:interval].any?(&:dst_adjust?)
     end
 
     def full_required?

--- a/lib/ice_cube/validated_rule.rb
+++ b/lib/ice_cube/validated_rule.rb
@@ -82,6 +82,10 @@ module IceCube
       @validations[:interval].any?(&:dst_adjust?)
     end
 
+    def full_required?
+      !occurrence_count.nil?
+    end
+
     def to_s
       builder = StringBuilder.new
       @validations.each_value do |validations|

--- a/lib/ice_cube/validations/count.rb
+++ b/lib/ice_cube/validations/count.rb
@@ -4,14 +4,13 @@ module IceCube
 
     # Value reader for limit
     def occurrence_count
-      @count
+      (arr = @validations[:count]) && (val = arr[0]) && val.count
     end
 
     def count(max)
       unless max.nil? || max.is_a?(Integer)
         raise ArgumentError, "Expecting Integer or nil value for count, got #{max.inspect}"
       end
-      @count = max
       replace_validations_for(:count, max && [Validation.new(max, self)])
       self
     end

--- a/lib/ice_cube/validations/day.rb
+++ b/lib/ice_cube/validations/day.rb
@@ -1,5 +1,3 @@
-require 'date'
-
 module IceCube
 
   module Validations::Day

--- a/lib/ice_cube/validations/until.rb
+++ b/lib/ice_cube/validations/until.rb
@@ -6,12 +6,11 @@ module IceCube
 
     # Value reader for limit
     def until_time
-      @until
+      (arr = @validations[:until]) && (val = arr[0]) && val.time
     end
     deprecated_alias :until_date, :until_time
 
     def until(time)
-      @until = time
       replace_validations_for(:until, time.nil? ? nil : [Validation.new(time)])
       self
     end

--- a/lib/ice_cube/validations/weekly_interval.rb
+++ b/lib/ice_cube/validations/weekly_interval.rb
@@ -1,5 +1,3 @@
-require 'date'
-
 module IceCube
 
   module Validations::WeeklyInterval

--- a/spec/examples/_no_active_support_spec.rb
+++ b/spec/examples/_no_active_support_spec.rb
@@ -21,9 +21,10 @@ module IceCube
 
         it 'should be able to calculate beginning of dates without active_support' do
           date = Date.new(2011, 1, 1)
-          res = [ TimeUtil.beginning_of_date(date), Time.local(2011, 1, 1, 0, 0, 0) ]
-          res.all? { |r| r.class.name == 'Time' }
-          expect(res.map(&:to_s).uniq.size).to eq(1)
+          midnight = TimeUtil.beginning_of_date(date)
+
+          expect(midnight).to eq(Time.local(2011, 1, 1, 0, 0, 0))
+          expect(midnight).to be_a Time
         end
 
         it 'should serialize to hash without error' do

--- a/spec/examples/active_support_spec.rb
+++ b/spec/examples/active_support_spec.rb
@@ -129,8 +129,8 @@ module IceCube
 
       it "uses schedule zone for occurrences_between with a rule terminated by #count" do
         utc = Time.utc(2013, 1, 1).in_time_zone('UTC')
-        s = Schedule.new(utc) { |s| s.add_recurrence_rule Rule.daily.count(3) }
-        occurrences_between = s.occurrences_between(reference_time, reference_time + IceCube::ONE_DAY)
+        schedule = Schedule.new(utc) { |s| s.add_recurrence_rule Rule.daily.count(3) }
+        occurrences_between = schedule.occurrences_between(reference_time, reference_time + IceCube::ONE_DAY)
         expect(occurrences_between).to eq([Time.utc(2013, 1, 1), Time.utc(2013, 1, 2)])
         occurrences_between.each do |t|
           expect(t.time_zone).to eq(schedule.start_time.time_zone)
@@ -139,8 +139,8 @@ module IceCube
 
       it "uses schedule zone for occurrences_between with a rule terminated by #until" do
         utc = Time.utc(2013, 1, 1).in_time_zone('UTC')
-        s = Schedule.new(utc) { |s| s.add_recurrence_rule Rule.daily.until(utc.advance(:days => 3)) }
-        occurrences_between = s.occurrences_between(reference_time, reference_time + IceCube::ONE_DAY)
+        schedule = Schedule.new(utc) { |s| s.add_recurrence_rule Rule.daily.until(utc.advance(:days => 3)) }
+        occurrences_between = schedule.occurrences_between(reference_time, reference_time + IceCube::ONE_DAY)
         expect(occurrences_between).to eq([Time.utc(2013, 1, 1), Time.utc(2013, 1, 2)])
         occurrences_between.each do |t|
           expect(t.time_zone).to eq(schedule.start_time.time_zone)
@@ -149,8 +149,8 @@ module IceCube
 
       it "uses schedule zone for occurrences_between with an unterminated rule" do
         utc = Time.utc(2013, 1, 1).in_time_zone('UTC')
-        s = Schedule.new(utc) { |s| s.add_recurrence_rule Rule.daily }
-        occurrences_between = s.occurrences_between(reference_time, reference_time + IceCube::ONE_DAY)
+        schedule = Schedule.new(utc) { |s| s.add_recurrence_rule Rule.daily }
+        occurrences_between = schedule.occurrences_between(reference_time, reference_time + IceCube::ONE_DAY)
         expect(occurrences_between).to eq([Time.utc(2013, 1, 1), Time.utc(2013, 1, 2)])
         occurrences_between.each do |t|
           expect(t.time_zone).to eq(schedule.start_time.time_zone)

--- a/spec/examples/active_support_spec.rb
+++ b/spec/examples/active_support_spec.rb
@@ -22,7 +22,7 @@ module IceCube
     end
 
     it 'works with a monthly recurrence rule starting from a TimeWithZone' do
-      schedule = Schedule.new(t0 = Time.zone.parse("2010-02-05 05:00:00"))
+      schedule = Schedule.new(Time.zone.parse("2010-02-05 05:00:00"))
       schedule.add_recurrence_rule Rule.monthly
       expect(schedule.first(10)).to eq([
         Time.zone.parse("2010-02-05 05:00"), Time.zone.parse("2010-03-05 05:00"),
@@ -35,7 +35,7 @@ module IceCube
 
     it 'works with a monthly schedule converting to UTC across DST' do
       Time.zone = 'Eastern Time (US & Canada)'
-      schedule = Schedule.new(t0 = Time.zone.parse("2009-10-28 19:30:00"))
+      schedule = Schedule.new(Time.zone.parse("2009-10-28 19:30:00"))
       schedule.add_recurrence_rule Rule.monthly
       expect(schedule.first(7).map { |d| d.getutc }).to eq([
         Time.utc(2009, 10, 28, 23, 30, 0), Time.utc(2009, 11, 29,  0, 30, 0),
@@ -53,13 +53,13 @@ module IceCube
     end
 
     it 'uses local zone from start time to determine occurs_on? from the beginning of day' do
-      schedule = Schedule.new(t0 = Time.local(2009, 2, 7, 23, 59, 59))
+      schedule = Schedule.new(Time.local(2009, 2, 7, 23, 59, 59))
       schedule.add_recurrence_rule Rule.daily
       expect(schedule.occurs_on?(Date.new(2009, 2, 7))).to be_truthy
     end
 
     it 'uses local zone from start time to determine occurs_on? to the end of day' do
-      schedule = Schedule.new(t0 = Time.local(2009, 2, 7, 0, 0, 0))
+      schedule = Schedule.new(Time.local(2009, 2, 7, 0, 0, 0))
       schedule.add_recurrence_rule Rule.daily
       expect(schedule.occurs_on?(Date.new(2009, 2, 7))).to be_truthy
     end

--- a/spec/examples/active_support_spec.rb
+++ b/spec/examples/active_support_spec.rb
@@ -3,7 +3,6 @@ require 'active_support/time'
 require 'active_support/version'
 require 'tzinfo' if ActiveSupport::VERSION::MAJOR == 3
 
-
 module IceCube
   describe Schedule, 'using ActiveSupport' do
 

--- a/spec/examples/daily_rule_spec.rb
+++ b/spec/examples/daily_rule_spec.rb
@@ -14,13 +14,13 @@ module IceCube
 
     it 'raises an argument error when a bad value is passed using the interval method' do
       expect {
-        rule = Rule.daily.interval("invalid")
+        Rule.daily.interval("invalid")
       }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
     end
 
     it 'raises an argument error when a bad value is passed' do
       expect {
-        rule = Rule.daily("invalid")
+        Rule.daily("invalid")
       }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
     end
   end
@@ -30,7 +30,7 @@ module IceCube
     describe 'in Vancouver time', :system_time_zone => 'America/Vancouver' do
 
       it 'should include nearest time in DST start hour' do
-        schedule = Schedule.new(t0 = Time.local(2013, 3, 9, 2, 30, 0))
+        schedule = Schedule.new(Time.local(2013, 3, 9, 2, 30, 0))
         schedule.add_recurrence_rule Rule.daily
         expect(schedule.first(3)).to eq([
           Time.local(2013, 3,  9, 2, 30, 0), # -0800
@@ -40,7 +40,7 @@ module IceCube
       end
 
       it 'should not skip times in DST end hour' do
-        schedule = Schedule.new(t0 = Time.local(2013, 11, 2, 2, 30, 0))
+        schedule = Schedule.new(Time.local(2013, 11, 2, 2, 30, 0))
         schedule.add_recurrence_rule Rule.daily
         expect(schedule.first(3)).to eq([
           Time.local(2013, 11, 2, 2, 30, 0), # -0700
@@ -50,7 +50,7 @@ module IceCube
       end
 
       it 'should include nearest time to DST start when locking hour_of_day' do
-        schedule = Schedule.new(t0 = Time.local(2013, 3, 9, 2, 0, 0))
+        schedule = Schedule.new(Time.local(2013, 3, 9, 2, 0, 0))
         schedule.add_recurrence_rule Rule.daily.hour_of_day(2)
         expect(schedule.first(3)).to eq([
           Time.local(2013, 3,  9, 2, 0, 0), # -0800

--- a/spec/examples/dst_spec.rb
+++ b/spec/examples/dst_spec.rb
@@ -37,10 +37,8 @@ module IceCube
       schedule.add_recurrence_rule Rule.daily
       # each occurrence MUST occur at 5pm, then we win
       dates = schedule.occurrences(start_time + 20 * ONE_DAY)
-      last = start_time
       dates.each do |date|
         expect(date.hour).to eq(5)
-        last = date
       end
     end
 

--- a/spec/examples/hourly_rule_spec.rb
+++ b/spec/examples/hourly_rule_spec.rb
@@ -15,13 +15,13 @@ module IceCube
 
       it 'raises an argument error when a bad value is passed' do
         expect {
-          rule = Rule.hourly("invalid")
+          Rule.hourly("invalid")
         }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
       end
 
       it 'raises an argument error when a bad value is passed using the interval method' do
         expect {
-          rule = Rule.hourly.interval("invalid")
+          Rule.hourly.interval("invalid")
         }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
       end
     end
@@ -29,7 +29,7 @@ module IceCube
     context 'in Vancouver time', :system_time_zone => 'America/Vancouver' do
 
       it 'should work across DST start hour' do
-        schedule = Schedule.new(t0 = Time.local(2013, 3, 10, 1, 0, 0))
+        schedule = Schedule.new(Time.local(2013, 3, 10, 1, 0, 0))
         schedule.add_recurrence_rule Rule.hourly
         expect(schedule.first(3)).to eq([
           Time.local(2013, 3, 10, 1, 0, 0), # -0800
@@ -39,7 +39,7 @@ module IceCube
       end
 
       it 'should not skip times in DST end hour' do
-        schedule = Schedule.new(t0 = Time.local(2013, 11, 3, 0, 0, 0))
+        schedule = Schedule.new(Time.local(2013, 11, 3, 0, 0, 0))
         schedule.add_recurrence_rule Rule.hourly
         expect(schedule.first(4)).to eq([
           Time.local(2013, 11, 3, 0, 0, 0),             # -0700

--- a/spec/examples/minutely_rule_spec.rb
+++ b/spec/examples/minutely_rule_spec.rb
@@ -14,13 +14,13 @@ module IceCube
 
     it 'raises an argument error when a bad value is passed' do
       expect {
-        rule = Rule.minutely("invalid")
+        Rule.minutely("invalid")
       }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
     end
 
     it 'raises an argument error when a bad value is passed when using the interval method' do
       expect {
-        rule = Rule.minutely.interval("invalid")
+        Rule.minutely.interval("invalid")
       }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
     end
 

--- a/spec/examples/monthly_rule_spec.rb
+++ b/spec/examples/monthly_rule_spec.rb
@@ -98,23 +98,20 @@ module IceCube
         }
 
         it "should not skip a month when DST ends" do
-          schedule.first(48).inject(nil) do |last_date, current_date|
-            next current_date unless last_date
-            expect(month_interval(current_date, last_date)).to eq(1)
+          schedule.first(48).each_cons(2) do |t0, t1|
+            expect(month_interval(t1, t0)).to eq(1)
           end
         end
 
         it "should not change day when DST ends" do
-          schedule.first(48).inject(nil) do |last_date, current_date|
-            next current_date unless last_date
-            expect(current_date.wday).to eq(wday)
+          schedule.first(48).each do |date|
+            expect(date.wday).to eq(wday)
           end
         end
 
         it "should not change hour when DST ends" do
-          schedule.first(48).inject(nil) do |last_date, current_date|
-            next current_date unless last_date
-            expect(current_date.hour).to eq(0)
+          schedule.first(48).each do |time|
+            expect(time.hour).to eq(0)
           end
         end
       end

--- a/spec/examples/monthly_rule_spec.rb
+++ b/spec/examples/monthly_rule_spec.rb
@@ -19,13 +19,13 @@ module IceCube
 
     it 'raises an argument error when a bad value is passed' do
       expect {
-        rule = Rule.monthly("invalid")
+        Rule.monthly("invalid")
       }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
     end
 
     it 'raises an argument error when a bad value is passed using the interval method' do
       expect {
-        rule = Rule.monthly.interval("invalid")
+        Rule.monthly.interval("invalid")
       }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
     end
   end
@@ -92,8 +92,9 @@ module IceCube
     [:sunday, :monday, :tuesday, :wednesday, :thursday, :friday, :saturday].each_with_index do |weekday, wday|
       context "for every first #{weekday} of a month" do
         let(:schedule) {
-          schedule = Schedule.new(t0 = Time.local(2011, 8, 1))
-          schedule.add_recurrence_rule Rule.monthly.day_of_week(weekday => [1])
+          Schedule.new(Time.local(2011, 8, 1)) do |s|
+            s.add_recurrence_rule Rule.monthly.day_of_week(weekday => [1])
+          end
         }
 
         it "should not skip a month when DST ends" do
@@ -120,7 +121,7 @@ module IceCube
     end
 
     it 'should produce dates on a monthly interval for the last day of the month' do
-      schedule = Schedule.new(t0 = Time.utc(2010, 3, 31, 0, 0, 0))
+      schedule = Schedule.new(Time.utc(2010, 3, 31, 0, 0, 0))
       schedule.add_recurrence_rule Rule.monthly
       expect(schedule.first(10)).to eq([
         Time.utc(2010,  3, 31, 0, 0, 0), Time.utc(2010,  4, 30, 0, 0, 0),
@@ -132,7 +133,7 @@ module IceCube
     end
 
     it 'should produce dates on a monthly interval for latter days in the month near February' do
-      schedule = Schedule.new(t0 = Time.utc(2010, 1, 29, 0, 0, 0))
+      schedule = Schedule.new(Time.utc(2010, 1, 29, 0, 0, 0))
       schedule.add_recurrence_rule Rule.monthly
       expect(schedule.first(3)).to eq([
         Time.utc(2010, 1, 29, 0, 0, 0),
@@ -142,7 +143,7 @@ module IceCube
     end
 
     it 'should restrict to available days of month when specified' do
-      schedule = Schedule.new(t0 = Time.utc(2013,1,31))
+      schedule = Schedule.new(Time.utc(2013,1,31))
       schedule.add_recurrence_rule Rule.monthly.day_of_month(31)
       expect(schedule.first(3)).to eq([
         Time.utc(2013, 1, 31),

--- a/spec/examples/occurrence_spec.rb
+++ b/spec/examples/occurrence_spec.rb
@@ -28,7 +28,6 @@ describe Occurrence do
     end
 
     it "accepts a format option to comply with ActiveSupport" do
-      # require 'active_support/core_ext/time'
       time_now = Time.current
       occurrence = Occurrence.new(time_now)
 

--- a/spec/examples/occurrence_spec.rb
+++ b/spec/examples/occurrence_spec.rb
@@ -1,7 +1,5 @@
 require File.dirname(__FILE__) + '/../spec_helper'
 
-include IceCube
-
 describe Occurrence do
 
   it "reports as a Time" do

--- a/spec/examples/occurrence_spec.rb
+++ b/spec/examples/occurrence_spec.rb
@@ -36,6 +36,40 @@ describe Occurrence do
     end
   end
 
+  describe :to_i do
+    it "represents the start time" do
+      start_time = Time.now
+      occurrence = Occurrence.new(start_time)
+
+      expect(occurrence.to_i).to eq start_time.to_i
+    end
+  end
+
+  describe :cover? do
+    let(:start_time) { Time.now }
+    let(:occurrence) { Occurrence.new(start_time, start_time + ONE_HOUR) }
+
+    it "is true for the start time" do
+      expect(occurrence.cover?(start_time)).to be true
+    end
+
+    it "is true for a time in the range" do
+      expect(occurrence.cover?(start_time + 1)).to be true
+    end
+
+    it "is true for the end time" do
+      expect(occurrence.cover?(start_time + ONE_HOUR)).to be true
+    end
+
+    it "is false after the end time" do
+      expect(occurrence.cover?(start_time + ONE_HOUR + 1)).to be false
+    end
+
+    it "is false before the start time" do
+      expect(occurrence.cover?(start_time - 1)).to be false
+    end
+  end
+
   describe :end_time do
 
     it 'defaults to start_time' do

--- a/spec/examples/occurrence_spec.rb
+++ b/spec/examples/occurrence_spec.rb
@@ -45,6 +45,20 @@ describe Occurrence do
     end
   end
 
+  describe :<=> do
+    it "is comparable to another occurrence's start time" do
+      o1 = Occurrence.new(Time.now)
+      o2 = Occurrence.new(o1.start_time + 1)
+
+      expect(o1).to be < o2
+    end
+
+    it "is comparable to another time" do
+      occurrence = Occurrence.new(Time.now)
+      expect(occurrence).to be < occurrence.start_time + 1
+    end
+  end
+
   describe :cover? do
     let(:start_time) { Time.now }
     let(:occurrence) { Occurrence.new(start_time, start_time + ONE_HOUR) }

--- a/spec/examples/recur_spec.rb
+++ b/spec/examples/recur_spec.rb
@@ -1,7 +1,5 @@
 require File.dirname(__FILE__) + '/../spec_helper'
 
-include IceCube
-
 describe :remaining_occurrences do
 
   it 'should get the proper remaining occurrences from now' do

--- a/spec/examples/regression_spec.rb
+++ b/spec/examples/regression_spec.rb
@@ -168,9 +168,9 @@ module IceCube
         it 'should exclude a date from a weekly schedule [#55]' do
           Time.zone = 'Eastern Time (US & Canada)'
           t0 = Time.zone.local(2011, 12, 27, 14)
-          schedule = Schedule.new(t0) do |schedule|
-            schedule.add_recurrence_rule Rule.weekly.day(:tuesday, :thursday)
-            schedule.add_exception_time t0
+          schedule = Schedule.new(t0) do |s|
+            s.add_recurrence_rule Rule.weekly.day(:tuesday, :thursday)
+            s.add_exception_time t0
           end
           expect(schedule.first).to eq(Time.zone.local(2011, 12, 29, 14))
         end

--- a/spec/examples/regression_spec.rb
+++ b/spec/examples/regression_spec.rb
@@ -12,7 +12,7 @@ module IceCube
         end
 
         it 'should consider recurrence times properly in find_occurreces [#43]' do
-          schedule = Schedule.new(t0 = Time.local(2011, 10, 1, 18, 25))
+          schedule = Schedule.new(Time.local(2011, 10, 1, 18, 25))
           schedule.add_recurrence_time Time.local(2011, 12, 3, 15, 0, 0)
           schedule.add_recurrence_time Time.local(2011, 12, 3, 10, 0, 0)
           schedule.add_recurrence_time Time.local(2011, 12, 4, 10, 0, 0)
@@ -20,7 +20,7 @@ module IceCube
         end
 
         it 'should work well with occurrences_between [#33]' do
-          schedule = Schedule.new(t0 = Time.local(2011, 10, 11, 12))
+          schedule = Schedule.new(Time.local(2011, 10, 11, 12))
           schedule.add_recurrence_rule Rule.weekly.day(1).hour_of_day(12).minute_of_hour(0)
           schedule.add_recurrence_rule Rule.weekly.day(2).hour_of_day(15).minute_of_hour(0)
           schedule.add_exception_time Time.local(2011, 10, 13, 21)
@@ -37,13 +37,13 @@ module IceCube
         end
 
         it 'should not regress [#40]' do
-          schedule = Schedule.new(t0 = Time.local(2011, 11, 16, 11, 31, 58), :duration => 3600)
+          schedule = Schedule.new(Time.local(2011, 11, 16, 11, 31, 58), :duration => 3600)
           schedule.add_recurrence_rule Rule.minutely(60).day(4).hour_of_day(14, 15, 16).minute_of_hour(0)
           expect(schedule.occurring_at?(Time.local(2011, 11, 17, 15, 30))).to be_falsey
         end
 
         it 'should not choke on parsing [#26]' do
-          schedule = Schedule.new(t0 = Time.local(2011, 8, 9, 14, 52, 14))
+          schedule = Schedule.new(Time.local(2011, 8, 9, 14, 52, 14))
           schedule.rrule Rule.weekly(1).day(1, 2, 3, 4, 5)
           expect { Schedule.from_yaml(schedule.to_yaml) }.to_not raise_error
         end
@@ -77,7 +77,7 @@ module IceCube
         end
 
         it 'should produce all occurrences between dates, not breaking on exceptions [#82]' do
-          schedule = Schedule.new(t0 = Time.new(2012, 5, 1))
+          schedule = Schedule.new(Time.new(2012, 5, 1))
           schedule.add_recurrence_rule Rule.daily.day(:sunday, :tuesday, :wednesday, :thursday, :friday, :saturday)
           times = schedule.occurrences_between(Time.new(2012, 5, 19), Time.new(2012, 5, 24))
           expect(times).to eq([
@@ -98,7 +98,7 @@ module IceCube
         end
 
         it 'should produce occurrences regardless of time being specified [#81]' do
-          schedule = Schedule.new(t0 = Time.new(2012, 5, 1))
+          schedule = Schedule.new(Time.new(2012, 5, 1))
           schedule.add_recurrence_rule Rule.daily.hour_of_day(8)
           times = schedule.occurrences_between(Time.new(2012, 05, 20), Time.new(2012, 05, 22))
           expect(times).to eq([
@@ -138,7 +138,7 @@ module IceCube
           :rtimes: []
           :extimes: []
           EOS
-          times = schedule.occurrences(Date.new(2013, 07, 13).to_time)
+          expect(schedule.occurrences(Date.new(2013, 07, 13).to_time)).to be_a Array
         end
 
         it 'should still include date over DST boundary [#98]', expect_warnings: true do # set local to Sweden
@@ -187,7 +187,7 @@ module IceCube
         end
 
         it 'should not infinite loop [#109]' do
-          schedule = Schedule.new(t0 = Time.new(2012, 4, 27, 0, 0, 0))
+          schedule = Schedule.new(Time.new(2012, 4, 27, 0, 0, 0))
           schedule.rrule Rule.weekly.day(:monday, :tuesday, :wednesday, :thursday, :friday, :saturday, :sunday).hour_of_day(0).minute_of_hour(0).second_of_minute(0)
           schedule.duration = 3600
           t1 = Time.new(2012, 10, 20, 0, 0, 0)
@@ -196,7 +196,7 @@ module IceCube
         end
 
         it 'should return next_occurrence in utc if start_time is utc [#115]' do
-          schedule = Schedule.new(t0 = Time.utc(2012, 10, 10, 20, 15, 0))
+          schedule = Schedule.new(Time.utc(2012, 10, 10, 20, 15, 0))
           schedule.rrule Rule.daily
           expect(schedule.next_occurrence).to be_utc
         end

--- a/spec/examples/rfc_spec.rb
+++ b/spec/examples/rfc_spec.rb
@@ -66,8 +66,7 @@ describe IceCube::Schedule do
   it 'should ~ weekly until december 24, 1997' do
     schedule = IceCube::Schedule.new(Time.utc(1997, 9, 2))
     schedule.add_recurrence_rule IceCube::Rule.weekly.until(Time.utc(1997, 12, 24))
-    dates = schedule.occurrences(Time.utc(1997, 12, 24))
-    #test expectations
+
     test_expectations(schedule, {1997 => {9 => [2, 9, 16, 23, 30], 10 => [7, 14, 21, 28], 11 => [4, 11, 18, 25], 12 => [2, 9, 16, 23]}})
   end
 
@@ -84,7 +83,6 @@ describe IceCube::Schedule do
     end
   end
 
-  #
   it 'should ~ weekly on tuesday and thursday for 5 weeks (a)' do
     start_time = Time.utc(1997, 9, 2)
     schedule = IceCube::Schedule.new(start_time)
@@ -107,7 +105,6 @@ describe IceCube::Schedule do
     expect(dates).to eq(expectation.flatten)
   end
 
-  #
   it 'should ~ every other week on monday, wednesday and friday until december 24, 1997 but starting on tuesday september 2, 1997' do
     start_time = Time.utc(1997, 9, 2)
     schedule = IceCube::Schedule.new(start_time)

--- a/spec/examples/secondly_rule_spec.rb
+++ b/spec/examples/secondly_rule_spec.rb
@@ -14,13 +14,13 @@ module IceCube
 
     it 'raises an argument error when a bad value is passed' do
       expect {
-        rule = Rule.secondly("invalid")
+        Rule.secondly("invalid")
       }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
     end
 
     it 'raises an argument error when a bad value is passed using the interval method' do
       expect {
-        rule = Rule.secondly.interval("invalid")
+        Rule.secondly.interval("invalid")
       }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
     end
   end

--- a/spec/examples/serialization_spec.rb
+++ b/spec/examples/serialization_spec.rb
@@ -46,7 +46,6 @@ describe IceCube::Schedule do
       let(:start_time) { Time.now.in_time_zone("America/Vancouver") }
 
       it "deserializes time from Hash" do
-        hash = YAML.load(yaml)
         expect(new_schedule.start_time).to eq start_time
         expect(new_schedule.start_time.time_zone).to eq start_time.time_zone
       end

--- a/spec/examples/time_util_spec.rb
+++ b/spec/examples/time_util_spec.rb
@@ -26,7 +26,7 @@ module IceCube
       it "returns 00:00:00 from UTC for local time" do
         time = TimeUtil.beginning_of_date(utc_time.to_date, dst_time)
         expect([time.hour, time.min, time.sec]).to eq [0, 0, 0]
-        expect(time.utc_offset).to eq (dst_time.utc_offset)
+        expect(time.utc_offset).to eq dst_time.utc_offset
       end
 
       it "returns 00:00:00 from local time for UTC" do

--- a/spec/examples/time_util_spec.rb
+++ b/spec/examples/time_util_spec.rb
@@ -37,7 +37,7 @@ module IceCube
 
       it "returns 00:00:00 from local time for nonlocal time" do
         time = TimeUtil.beginning_of_date(dst_time.to_date, std_time.getlocal(7200))
-        zone_diff = dst_time.utc_offset - 7200
+
         expect([time.hour, time.min, time.sec]).to eq [0, 0, 0]
         expect(time.utc_offset).to eq 7200
       end

--- a/spec/examples/to_ical_spec.rb
+++ b/spec/examples/to_ical_spec.rb
@@ -214,13 +214,13 @@ describe IceCube, 'to_ical' do
   end
 
   it 'should be able to serialize to ical with an until date' do
-    rule = IceCube::Rule.weekly.until Time.now
-    expect(rule.to_ical).to match /^FREQ=WEEKLY;UNTIL=\d{8}T\d{6}Z$/
+    rule = IceCube::Rule.weekly.until Time.utc(2123, 12, 31, 12, 34, 56.25)
+    expect(rule.to_ical).to match "FREQ=WEEKLY;UNTIL=21231231T123456Z"
   end
 
   it 'should be able to serialize to ical with a count date' do
     rule = IceCube::Rule.weekly.count(5)
-    expect(rule.to_ical).to match /^FREQ=WEEKLY;COUNT=5$/
+    expect(rule.to_ical).to eq "FREQ=WEEKLY;COUNT=5"
   end
 
   %w{secondly minutely hourly daily monthly yearly}.each do |mthd|

--- a/spec/examples/to_s_en_spec.rb
+++ b/spec/examples/to_s_en_spec.rb
@@ -1,6 +1,4 @@
 require File.dirname(__FILE__) + '/../spec_helper'
-require 'i18n'
-require 'ice_cube/null_i18n'
 
 describe IceCube::Schedule, 'to_s' do
 

--- a/spec/examples/to_s_ja_spec.rb
+++ b/spec/examples/to_s_ja_spec.rb
@@ -107,21 +107,24 @@ describe IceCube::Schedule, 'to_s' do
   end
 
   it 'should order dates that are out of order' do
-    schedule = IceCube::Schedule.new(t0 = Time.local(2010, 3, 20))
-    schedule.add_recurrence_time t1 = Time.local(2010, 3, 19)
+    schedule = IceCube::Schedule.new(Time.local(2010, 3, 20)) do |s|
+      s.add_recurrence_time s.start_time - ONE_DAY
+    end
     expect(schedule.to_s).to eq('2010年03月19日 / 2010年03月20日')
   end
 
   it 'should remove duplicated start time' do
-    schedule = IceCube::Schedule.new t0 = Time.local(2010, 3, 20)
-    schedule.add_recurrence_time t0
+    schedule = IceCube::Schedule.new(Time.local(2010, 3, 20)) do |s|
+      s.add_recurrence_time s.start_time
+    end
     expect(schedule.to_s).to eq('2010年03月20日')
   end
 
   it 'should remove duplicate rtimes' do
-    schedule = IceCube::Schedule.new t0 = Time.local(2010, 3, 19)
-    schedule.add_recurrence_time Time.local(2010, 3, 20)
-    schedule.add_recurrence_time Time.local(2010, 3, 20)
+    schedule = IceCube::Schedule.new(Time.local(2010, 3, 19)) do |s|
+      s.add_recurrence_time s.start_time + ONE_DAY
+      s.add_recurrence_time s.start_time + ONE_DAY
+    end
     expect(schedule.to_s).to eq('2010年03月19日 / 2010年03月20日')
   end
 

--- a/spec/examples/to_s_ja_spec.rb
+++ b/spec/examples/to_s_ja_spec.rb
@@ -1,15 +1,7 @@
 # encoding: utf-8
 require File.dirname(__FILE__) + '/../spec_helper'
 
-describe IceCube::Schedule, 'to_s' do
-
-  before :each do
-    I18n.locale = :ja
-  end
-
-  after :all do
-    I18n.locale = :en
-  end
+describe IceCube::Schedule, 'to_s', locale: 'ja' do
 
   it 'should represent its start time by default' do
     t0 = Time.local(2013, 2, 14)

--- a/spec/examples/to_yaml_spec.rb
+++ b/spec/examples/to_yaml_spec.rb
@@ -1,10 +1,12 @@
 require File.dirname(__FILE__) + '/../spec_helper'
-require 'active_support/time'
 
 module IceCube
   describe Schedule, 'to_yaml' do
 
-    before(:all) { Time.zone = 'Eastern Time (US & Canada)' }
+    before(:all) do
+      require 'active_support/time'
+      Time.zone = 'Eastern Time (US & Canada)'
+    end
 
     [:yearly, :monthly, :weekly, :daily, :hourly, :minutely, :secondly].each do |type|
       it "should make a #{type} round trip with to_yaml [#47]" do

--- a/spec/examples/to_yaml_spec.rb
+++ b/spec/examples/to_yaml_spec.rb
@@ -10,7 +10,7 @@ module IceCube
 
     [:yearly, :monthly, :weekly, :daily, :hourly, :minutely, :secondly].each do |type|
       it "should make a #{type} round trip with to_yaml [#47]" do
-        schedule = Schedule.new(t0 = Time.now)
+        schedule = Schedule.new(Time.now)
         schedule.add_recurrence_rule Rule.send(type, 3)
         expect(Schedule.from_yaml(schedule.to_yaml).first(3).inspect).to eq(schedule.first(3).inspect)
       end
@@ -216,7 +216,6 @@ module IceCube
     end
 
     it 'should be backward compatible with old yaml Time format', expect_warnings: true do
-      pacific_time = 'Pacific Time (US & Canada)'
       yaml = "---\n:end_time:\n:rdates: []\n:rrules: []\n:duration:\n:exdates: []\n:start_time: 2010-10-18T14:35:47-07:00"
       schedule = Schedule.from_yaml(yaml)
       expect(schedule.start_time).to be_a(Time)

--- a/spec/examples/weekly_rule_spec.rb
+++ b/spec/examples/weekly_rule_spec.rb
@@ -14,13 +14,13 @@ module IceCube
 
     it 'raises an argument error when a bad value is passed' do
       expect {
-        rule = Rule.weekly("invalid")
+        Rule.weekly("invalid")
       }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
     end
 
     it 'raises an argument error when a bad value is passed using the interval method' do
       expect {
-        rule = Rule.weekly.interval("invalid")
+        Rule.weekly.interval("invalid")
       }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
     end
   end
@@ -30,7 +30,7 @@ module IceCube
     context 'in Vancouver time', :system_time_zone => 'America/Vancouver' do
 
       it 'should include nearest time in DST start hour' do
-        schedule = Schedule.new(t0 = Time.local(2013, 3, 3, 2, 30, 0))
+        schedule = Schedule.new(Time.local(2013, 3, 3, 2, 30, 0))
         schedule.add_recurrence_rule Rule.weekly
         expect(schedule.first(3)).to eq([
           Time.local(2013, 3,  3, 2, 30, 0), # -0800
@@ -40,7 +40,7 @@ module IceCube
       end
 
       it 'should not skip times in DST end hour' do
-        schedule = Schedule.new(t0 = Time.local(2013, 10, 27, 2, 30, 0))
+        schedule = Schedule.new(Time.local(2013, 10, 27, 2, 30, 0))
         schedule.add_recurrence_rule Rule.weekly
         expect(schedule.first(3)).to eq([
           Time.local(2013, 10, 27, 2, 30, 0), # -0700
@@ -74,31 +74,31 @@ module IceCube
     end
 
     it 'should set days from symbol args' do
-      schedule = Schedule.new(t0 = WEDNESDAY)
+      schedule = Schedule.new(WEDNESDAY)
       schedule.add_recurrence_rule Rule.weekly.day(:monday, :wednesday)
       expect(schedule.rrules.first.validations_for(:day).map(&:day)).to eq([1, 3])
     end
 
     it 'should set days from array of symbols' do
-      schedule = Schedule.new(t0 = WEDNESDAY)
+      schedule = Schedule.new(WEDNESDAY)
       schedule.add_recurrence_rule Rule.weekly.day([:monday, :wednesday])
       expect(schedule.rrules.first.validations_for(:day).map(&:day)).to eq([1, 3])
     end
 
     it 'should set days from integer args' do
-      schedule = Schedule.new(t0 = WEDNESDAY)
+      schedule = Schedule.new(WEDNESDAY)
       schedule.add_recurrence_rule Rule.weekly.day(1, 3)
       expect(schedule.rrules.first.validations_for(:day).map(&:day)).to eq([1, 3])
     end
 
     it 'should set days from array of integers' do
-      schedule = Schedule.new(t0 = WEDNESDAY)
+      schedule = Schedule.new(WEDNESDAY)
       schedule.add_recurrence_rule Rule.weekly.day([1, 3])
       expect(schedule.rrules.first.validations_for(:day).map(&:day)).to eq([1, 3])
     end
 
     it 'should raise an error on invalid input' do
-      schedule = Schedule.new(t0 = WEDNESDAY)
+      schedule = Schedule.new(WEDNESDAY)
       expect { schedule.add_recurrence_rule Rule.weekly.day(["1", "3"]) }.to raise_error(ArgumentError)
     end
 
@@ -127,7 +127,7 @@ module IceCube
     end
 
     it 'should occur every 2nd tuesday of a month' do
-      schedule = Schedule.new(t0 = Time.now)
+      schedule = Schedule.new(Time.now)
       schedule.add_recurrence_rule Rule.monthly.hour_of_day(11).day_of_week(:tuesday => [2])
       schedule.first(48).each do |d|
         expect(d.hour).to eq(11)
@@ -136,7 +136,7 @@ module IceCube
     end
 
     it 'should be able to start on sunday but repeat on wednesdays' do
-      schedule = Schedule.new(t0 = Time.local(2010, 8, 1))
+      schedule = Schedule.new(Time.local(2010, 8, 1))
       schedule.add_recurrence_rule Rule.weekly.day(:monday)
       expect(schedule.first(3)).to eq([
         Time.local(2010, 8,  2),
@@ -153,7 +153,7 @@ module IceCube
     # 19 20 21 22 23 24 25
     # 26 27 28 29
     it 'should start weekly rules on monday when monday is the week start' do
-      schedule = Schedule.new(t0 = Time.local(2012, 2, 7))
+      schedule = Schedule.new(Time.local(2012, 2, 7))
       schedule.add_recurrence_rule Rule.weekly(2, :monday).day(:tuesday, :sunday)
       expect(schedule.first(3)).to eq([
         Time.local(2012, 2,  7),
@@ -163,7 +163,7 @@ module IceCube
     end
 
     it 'should start weekly rules on sunday by default' do
-      schedule = Schedule.new(t0 = Time.local(2012,2,7))
+      schedule = Schedule.new(Time.local(2012,2,7))
       schedule.add_recurrence_rule Rule.weekly(2).day(:tuesday, :sunday)
       expect(schedule.first(3)).to eq([
         Time.local(2012, 2,  7),
@@ -225,7 +225,7 @@ module IceCube
     end
 
     it 'should produce correct days for bi-weekly interval, starting on a non-sunday' do
-      schedule = IceCube::Schedule.new(t0 = Time.local(2015, 3, 3))
+      schedule = IceCube::Schedule.new(Time.local(2015, 3, 3))
       schedule.add_recurrence_rule IceCube::Rule.weekly(2, :monday).day(:tuesday)
       range_start = Time.local(2015, 3, 15)
       times = schedule.occurrences_between(range_start, range_start + IceCube::ONE_WEEK)
@@ -233,7 +233,7 @@ module IceCube
     end
 
     it 'should produce correct days for monday-based bi-weekly interval, starting on a sunday' do
-      schedule = IceCube::Schedule.new(t0 = Time.local(2015, 3, 1))
+      schedule = IceCube::Schedule.new(Time.local(2015, 3, 1))
       schedule.add_recurrence_rule IceCube::Rule.weekly(2, :monday).day(:sunday)
       range_start = Time.local(2015, 3, 1)
       times = schedule.occurrences_between(range_start, range_start + IceCube::ONE_WEEK)
@@ -260,7 +260,7 @@ module IceCube
       # 26 27 28 29 30
 
       it "should align next_occurrences with first valid weekday when schedule starts on a Monday" do
-        schedule = IceCube::Schedule.new(t0 = Time.utc(2017, 6, 5))
+        schedule = IceCube::Schedule.new(Time.utc(2017, 6, 5))
         except_tuesday = [:monday, :wednesday, :thursday, :friday, :saturday, :sunday]
         schedule.add_recurrence_rule IceCube::Rule.weekly(2, :monday).day(except_tuesday)
         sample = [

--- a/spec/examples/yearly_rule_spec.rb
+++ b/spec/examples/yearly_rule_spec.rb
@@ -13,13 +13,13 @@ describe IceCube::YearlyRule, 'interval validation' do
 
   it 'raises an argument error when a bad value is passed' do
     expect {
-      rule = Rule.yearly("invalid")
+      Rule.yearly("invalid")
     }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
   end
 
   it 'raises an argument error when a bad value is passed using the interval method' do
     expect {
-      rule = Rule.yearly.interval("invalid")
+      Rule.yearly.interval("invalid")
     }.to raise_error(ArgumentError, "'invalid' is not a valid input for interval. Please pass a postive integer.")
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,17 @@ WORLD_TIME_ZONES = [
   'Pacific/Auckland',   # +1200 / +1300
 ]
 
+# TODO: enable warnings here and update specs to call IceCube objects correctly
+def Object.const_missing(sym)
+  case sym
+  when :Schedule, :Rule, :Occurrence, :TimeUtil, :ONE_DAY, :ONE_HOUR, :ONE_MINUTE
+    # warn "Use IceCube::#{sym}", caller[0]
+    IceCube.const_get(sym)
+  else
+    super
+  end
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,15 +48,11 @@ RSpec.configure do |config|
     end
   end
 
-  config.around :each do |example|
-    if zone = example.metadata[:system_time_zone]
-      orig_zone = ENV['TZ']
-      ENV['TZ'] = zone
-      example.run
-      ENV['TZ'] = orig_zone
-    else
-      example.run
-    end
+  config.around :each, system_time_zone: true do |example|
+    orig_zone = ENV['TZ']
+    ENV['TZ'] = example.metadata[:system_time_zone]
+    example.run
+    ENV['TZ'] = orig_zone
   end
 
   config.around :each, locale: true do |example|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,8 @@ RSpec.configure do |config|
 
   Dir[File.dirname(__FILE__) + '/support/**/*'].each { |f| require f }
 
+  config.warnings = true
+
   config.include WarningHelpers
 
   config.before :each do |example|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,6 +59,13 @@ RSpec.configure do |config|
     end
   end
 
+  config.around :each, locale: true do |example|
+    orig_locale = I18n.locale
+    I18n.locale = example.metadata[:locale]
+    example.run
+    I18n.locale = orig_locale
+  end
+
   config.around :each, expect_warnings: true do |example|
     capture_warnings do
       example.run


### PR DESCRIPTION
Update code and specs to silence warnings. One valid warning remains for:

```
warning: assigned but unused variable - tzid
```

This final warning should be addressed for #407.