### PR TITLE
Quick language correction to a day name

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -137,7 +137,7 @@ fr:
     - dimanche
     - lundi
     - mardi
-    - mecredi
+    - mercredi
     - jeudi
     - vendredi
     - samedi


### PR DESCRIPTION
In French, mecredi is mercredi