### PR TITLE
Update README with RDATE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ the schedule's start_time. Schedule start times are supported as:
 ice_cube implements its own hash-based .to_yaml, so you can quickly (and
 safely) serialize schedule objects in and out of your data store
 
-It also supports partial serialization to/from `ICAL`. `RDATE` are not supported yet.
+It also supports serialization to/from `ICAL`.
 
 ``` ruby
 yaml = schedule.to_yaml

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ the schedule's start_time. Schedule start times are supported as:
 ice_cube implements its own hash-based .to_yaml, so you can quickly (and
 safely) serialize schedule objects in and out of your data store
 
-It also supports serialization to/from `ICAL`.
+It also supports partial serialization to/from `ICAL`. Parsing datetimes with time zone information is not currently supported.
 
 ``` ruby
 yaml = schedule.to_yaml


### PR DESCRIPTION
I believe 0.16.3 added RDATE support ~~making ical serialization fully supported (?)~~

Update:
Looks like parsing time zone information still isn't supported at the moment. Added note about that.

Update 2:
Also added time zone parsing support in #455.