### PR TITLE
Add timezone parsing / serializing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@
 
 # rspec failure tracking
 .rspec_status
+
+# Vagrant files
+Vagrantfile
+.vagrant
+ubuntu*

--- a/lib/ice_cube/builders/ical_builder.rb
+++ b/lib/ice_cube/builders/ical_builder.rb
@@ -37,11 +37,13 @@ module IceCube
 
     def self.ical_format(time, force_utc)
       time = time.dup.utc if force_utc
+
       if time.utc?
         ":#{IceCube::I18n.l(time, format: '%Y%m%dT%H%M%SZ')}" # utc time
+      elsif time.respond_to?(:time_zone)
+        ";TZID=#{time.time_zone.name}:#{IceCube::I18n.l(time, format: '%Y%m%dT%H%M%S')}" # time zone specified
       else
-        time_zone = time.respond_to?(:time_zone) ? time.time_zone.name : time.zone
-        ";TZID=#{time_zone}:#{IceCube::I18n.l(time, format: '%Y%m%dT%H%M%S')}" # local time specified
+        ":#{IceCube::I18n.l(time, format: '%Y%m%dT%H%M%S')}" # local time specified
       end
     end
 

--- a/lib/ice_cube/parsers/ical_parser.rb
+++ b/lib/ice_cube/parsers/ical_parser.rb
@@ -5,17 +5,19 @@ module IceCube
       ical_string.each_line do |line|
         (property, value) = line.split(':')
         (property, tzid) = property.split(';')
+        (_, time_zone) = tzid.split('=') if tzid
+
         case property
         when 'DTSTART'
-          data[:start_time] = TimeUtil.deserialize_time(value)
+          data[:start_time] = TimeUtil.deserialize_time({time: value, zone: time_zone})
         when 'DTEND'
-          data[:end_time] = TimeUtil.deserialize_time(value)
+          data[:end_time] = TimeUtil.deserialize_time({time: value, zone: time_zone})
         when 'RDATE'
           data[:rtimes] ||= []
-          data[:rtimes] += value.split(',').map { |v| TimeUtil.deserialize_time(v) }
+          data[:rtimes] += value.split(',').map { |v| TimeUtil.deserialize_time({time: v, zone: time_zone}) }
         when 'EXDATE'
           data[:extimes] ||= []
-          data[:extimes] += value.split(',').map { |v| TimeUtil.deserialize_time(v) }
+          data[:extimes] += value.split(',').map { |v| TimeUtil.deserialize_time({time: v, zone: time_zone}) }
         when 'DURATION'
           data[:duration] # FIXME
         when 'RRULE'

--- a/lib/ice_cube/time_util.rb
+++ b/lib/ice_cube/time_util.rb
@@ -109,10 +109,10 @@ module IceCube
       when Time, Date
         time_or_hash
       when DateTime
-        Time.local(time.year, time.month, time.day, time.hour, time.min, time.sec)
+        Time.local(time_or_hash.year, time_or_hash.month, time_or_hash.day, time_or_hash.hour, time_or_hash.min, time_or_hash.sec)
       when Hash
         hash = FlexibleHash.new(time_or_hash)
-        hash[:time].in_time_zone(hash[:zone])
+        hash[:zone] ? hash[:time].in_time_zone(hash[:zone]) : hash[:time]
       when String
         Time.parse(time_or_hash)
       end

--- a/spec/examples/to_ical_spec.rb
+++ b/spec/examples/to_ical_spec.rb
@@ -201,7 +201,7 @@ describe IceCube, 'to_ical' do
   it 'should default to to_ical using local time' do
     time = Time.now
     schedule = IceCube::Schedule.new(Time.now)
-    expect(schedule.to_ical).to eq("DTSTART;TZID=#{time.zone}:#{time.strftime('%Y%m%dT%H%M%S')}") # default false
+    expect(schedule.to_ical).to eq("DTSTART:#{time.strftime('%Y%m%dT%H%M%S')}") # default false
   end
 
   it 'should not have an rtime that duplicates start time' do
@@ -214,8 +214,8 @@ describe IceCube, 'to_ical' do
   it 'should be able to receive a to_ical in utc time' do
     time = Time.now
     schedule = IceCube::Schedule.new(Time.now)
-    expect(schedule.to_ical).to eq("DTSTART;TZID=#{time.zone}:#{time.strftime('%Y%m%dT%H%M%S')}") # default false
-    expect(schedule.to_ical(false)).to eq("DTSTART;TZID=#{time.zone}:#{time.strftime('%Y%m%dT%H%M%S')}")
+    expect(schedule.to_ical).to eq("DTSTART:#{time.strftime('%Y%m%dT%H%M%S')}") # default false
+    expect(schedule.to_ical(false)).to eq("DTSTART:#{time.strftime('%Y%m%dT%H%M%S')}")
     expect(schedule.to_ical(true)).to  eq("DTSTART:#{time.utc.strftime('%Y%m%dT%H%M%S')}Z")
   end
 


### PR DESCRIPTION
This PR updates the `full_tz` branch with correct timezone parsing / serializing. I'll add some comments in the code to explain some of the changes. It uses the `responds_to?(:time_zone)` method you already had in place to check for `ActiveSupport`.