### PR TITLE
Incorrect Swedish abbreviated month for November

### DIFF
--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -127,7 +127,7 @@ sv:
     - Aug
     - Sep
     - Okt
-    - Mov
+    - Nov
     - Dec
     day_names:
     - Söndag


### PR DESCRIPTION
'Mov' should be 'Nov'