### PR TITLE
Fix for I18n 1.2.0 changing handling of integer keys 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 
 # rspec failure tracking
 .rspec_status
+.byebug_history

--- a/ice_cube.gemspec
+++ b/ice_cube.gemspec
@@ -21,4 +21,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec', '> 3')
+
+  s.add_runtime_dependency('i18n', '~> 1.2.0')
 end

--- a/lib/ice_cube/builders/string_builder.rb
+++ b/lib/ice_cube/builders/string_builder.rb
@@ -21,8 +21,8 @@ module IceCube
           next if segments.empty?
           current = self.class.sentence(segments)
         end
-        f = IceCube::I18n.t('ice_cube.string.format')[type] ? type : 'default'
-        string = IceCube::I18n.t("ice_cube.string.format.#{f}", rest: string, current: current)
+        ext_format = IceCube::I18n.t("ice_cube.string.format.#{type}") ? type : 'default'
+        string = IceCube::I18n.t("ice_cube.string.format.#{ext_format}", rest: string, current: current)
       end
       string
     end
@@ -57,13 +57,13 @@ module IceCube
       end
 
       def literal_ordinal(number)
-        IceCube::I18n.t("ice_cube.integer.literal_ordinals")[number]
+        IceCube::I18n.t("ice_cube.integer.literal_ordinals.#{number}", default: nil)
       end
 
       def ordinal(number)
-        ord = IceCube::I18n.t("ice_cube.integer.ordinals")[number] ||
-          IceCube::I18n.t("ice_cube.integer.ordinals")[number % 10] ||
-          IceCube::I18n.t('ice_cube.integer.ordinals')[:default]
+        ord = IceCube::I18n.t("ice_cube.integer.ordinals.#{number}", default: nil) ||
+          IceCube::I18n.t("ice_cube.integer.ordinals.#{number % 10}", default: nil) ||
+          IceCube::I18n.t('ice_cube.integer.ordinals.default')
         number >= 0 ? ord : IceCube::I18n.t("ice_cube.integer.negative", ordinal: ord)
       end
 

--- a/lib/ice_cube/version.rb
+++ b/lib/ice_cube/version.rb
@@ -1,5 +1,3 @@
 module IceCube
-
-  VERSION = '0.16.3'
-
+  VERSION = '0.16.4'
 end

--- a/spec/examples/string_builder_spec.rb
+++ b/spec/examples/string_builder_spec.rb
@@ -1,9 +1,11 @@
 require File.dirname(__FILE__) + '/../spec_helper'
 
 describe IceCube::StringBuilder do
+  before :each do
+    I18n.locale = :en
+  end
 
   describe :sentence do
-
     it 'should return empty string when none' do
       expect(IceCube::StringBuilder.sentence([])).to eq('')
     end
@@ -19,7 +21,27 @@ describe IceCube::StringBuilder do
     it 'should comma and when more than two' do
       expect(IceCube::StringBuilder.sentence(['1', '2', '3'])).to eq('1, 2, and 3')
     end
-
   end
 
+  describe :nice_number do
+    it "should return 1st for 1" do
+      expect(IceCube::StringBuilder.nice_number(1)).to eq("1st")
+    end
+
+    it "should return 2nd for 2" do
+      expect(IceCube::StringBuilder.nice_number(2)).to eq("2nd")
+    end
+
+    it "should return 3rd for 3" do
+      expect(IceCube::StringBuilder.nice_number(3)).to eq("3rd")
+    end
+
+    it "should return last for -1" do
+      expect(IceCube::StringBuilder.nice_number(-1)).to eq("last")
+    end
+
+    it "should return 2nd to last for -2" do
+      expect(IceCube::StringBuilder.nice_number(-2)).to eq("2nd to last")
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require "bundler/setup"
 require 'ice_cube'
 require 'timeout'
+require 'i18n'
 
 begin
   require 'simplecov'
@@ -8,6 +9,8 @@ begin
 rescue LoadError
   # okay
 end
+
+I18n.config.available_locales = [:en, :es, :de, :fr, :ja, :nl, :"pt-BR", :ru, :sv] 
 
 IceCube.compatibility = 12
 


### PR DESCRIPTION
This fix restores the handling of ordinal internationalization by adapting to the changes made for `i18n` in svenfuchs/i18n#422.