### PR TITLE
Add support for BYSETPOS (monthly and yearly frequency)

### DIFF
--- a/lib/ice_cube.rb
+++ b/lib/ice_cube.rb
@@ -50,6 +50,9 @@ module IceCube
     autoload :YearlyInterval, 'ice_cube/validations/yearly_interval'
     autoload :HourlyInterval, 'ice_cube/validations/hourly_interval'
 
+    autoload :MonthlyBySetPos, 'ice_cube/validations/monthly_by_set_pos'
+    autoload :YearlyBySetPos, 'ice_cube/validations/yearly_by_set_pos'
+
     autoload :HourOfDay, 'ice_cube/validations/hour_of_day'
     autoload :MonthOfYear, 'ice_cube/validations/month_of_year'
     autoload :MinuteOfHour, 'ice_cube/validations/minute_of_hour'

--- a/lib/ice_cube/parsers/ical_parser.rb
+++ b/lib/ice_cube/parsers/ical_parser.rb
@@ -75,6 +75,7 @@ module IceCube
         when 'BYYEARDAY'
           validations[:day_of_year] = value.split(',').map(&:to_i)
         when 'BYSETPOS'
+          params[:validations][:by_set_pos] = value.split(',').collect(&:to_i)
         else
           validations[name] = nil # invalid type
         end

--- a/lib/ice_cube/rules/monthly_rule.rb
+++ b/lib/ice_cube/rules/monthly_rule.rb
@@ -12,6 +12,7 @@ module IceCube
     # include Validations::DayOfYear    # n/a
 
     include Validations::MonthlyInterval
+    include Validations::MonthlyBySetPos
 
     def initialize(interval = 1)
       super

--- a/lib/ice_cube/rules/yearly_rule.rb
+++ b/lib/ice_cube/rules/yearly_rule.rb
@@ -12,6 +12,7 @@ module IceCube
     include Validations::DayOfYear
 
     include Validations::YearlyInterval
+    include Validations::YearlyBySetPos
 
     def initialize(interval = 1)
       super

--- a/lib/ice_cube/time_util.rb
+++ b/lib/ice_cube/time_util.rb
@@ -1,7 +1,5 @@
 require 'date'
 require 'time'
-require 'active_support'
-require 'active_support/core_ext'
 
 module IceCube
   module TimeUtil

--- a/lib/ice_cube/time_util.rb
+++ b/lib/ice_cube/time_util.rb
@@ -1,5 +1,7 @@
 require 'date'
 require 'time'
+require 'active_support'
+require 'active_support/core_ext'
 
 module IceCube
   module TimeUtil

--- a/lib/ice_cube/validated_rule.rb
+++ b/lib/ice_cube/validated_rule.rb
@@ -20,7 +20,8 @@ module IceCube
       :base_sec, :base_min, :base_day, :base_hour, :base_month, :base_wday,
       :day_of_year, :second_of_minute, :minute_of_hour, :day_of_month,
       :hour_of_day, :month_of_year, :day_of_week,
-      :interval
+      :interval,
+      :by_set_pos
     ]
 
     attr_reader :validations

--- a/lib/ice_cube/validations/monthly_by_set_pos.rb
+++ b/lib/ice_cube/validations/monthly_by_set_pos.rb
@@ -4,7 +4,7 @@ module IceCube
     def by_set_pos(*by_set_pos)
       by_set_pos.flatten!
       by_set_pos.each do |set_pos|
-        unless (-366..366).include(set_pos) && set_pos != 0
+        unless (-366..366).cover?(set_pos) && set_pos != 0
           raise ArgumentError, "Expecting number in [-366, -1] or [1, 366], got #{set_pos} (#{by_set_pos})"
         end
       end

--- a/lib/ice_cube/validations/monthly_by_set_pos.rb
+++ b/lib/ice_cube/validations/monthly_by_set_pos.rb
@@ -35,7 +35,7 @@ module IceCube
         start_of_month = step_time.beginning_of_month
         end_of_month = step_time.end_of_month
 
-        new_schedule = IceCube::Schedule.new(step_time.last_month) do |s|
+        new_schedule = IceCube::Schedule.new(step_time.prev_month) do |s|
           s.add_recurrence_rule IceCube::Rule.from_hash(rule.to_hash.except(:by_set_pos, :count, :util))
         end
 

--- a/lib/ice_cube/validations/monthly_by_set_pos.rb
+++ b/lib/ice_cube/validations/monthly_by_set_pos.rb
@@ -1,0 +1,73 @@
+module IceCube
+  module Validations::MonthlyBySetPos
+
+    def by_set_pos(*by_set_pos)
+      by_set_pos.flatten!
+      by_set_pos.each do |set_pos|
+        unless (-366..366).include(set_pos) && set_pos != 0
+          raise ArgumentError, "Expecting number in [-366, -1] or [1, 366], got #{set_pos} (#{by_set_pos})"
+        end
+      end
+
+      @by_set_pos = by_set_pos
+      replace_validations_for(:by_set_pos, [Validation.new(by_set_pos, self)])
+      self
+    end
+
+    class Validation
+
+      attr_reader :rule, :by_set_pos
+
+      def initialize(by_set_pos, rule)
+        @by_set_pos = by_set_pos
+        @rule = rule
+      end
+
+      def type
+        :day
+      end
+
+      def dst_adjust?
+        true
+      end
+
+      def validate(step_time, schedule)
+        start_of_month = step_time.start_of_month
+        end_of_month = step_time.end_of_month
+
+        new_schedule = IceCube::Schedule.new(step_time.last_month) do |s|
+          s.add_recurrence_rule IceCube::Rule.from_hash(rule.to_hash.except(:by_set_pos, :count, :util))
+        end
+
+        occurrences = new_schedule.occurrences_between(start_of_month, end_of_month)
+        index = occurrences.index(step_time)
+        if index.nil?
+          1
+        else
+          positive_set_pos = index + 1
+          negative_set_pos = index - occurrences.length
+
+          if @by_set_pos.include?(positive_set_pos) || @by_set_pos.include?(negative_set_pos)
+            0
+          else
+            1
+          end
+        end
+      end
+
+      def build_s(builder)
+        builder.piece(:by_set_pos) << by_set_pos
+      end
+
+      def build_hash(builder)
+        builder[:by_set_pos] = by_set_pos
+      end
+
+      def build_ical(builder)
+        builder['BYSETPOS'] << by_set_pos
+      end
+
+      nil
+    end
+  end
+end

--- a/lib/ice_cube/validations/monthly_by_set_pos.rb
+++ b/lib/ice_cube/validations/monthly_by_set_pos.rb
@@ -32,7 +32,7 @@ module IceCube
       end
 
       def validate(step_time, schedule)
-        start_of_month = step_time.start_of_month
+        start_of_month = step_time.beginning_of_month
         end_of_month = step_time.end_of_month
 
         new_schedule = IceCube::Schedule.new(step_time.last_month) do |s|

--- a/lib/ice_cube/validations/monthly_by_set_pos.rb
+++ b/lib/ice_cube/validations/monthly_by_set_pos.rb
@@ -36,7 +36,7 @@ module IceCube
         end_of_month = step_time.end_of_month
 
         new_schedule = IceCube::Schedule.new(step_time.prev_month) do |s|
-          s.add_recurrence_rule IceCube::Rule.from_hash(rule.to_hash.except(:by_set_pos, :count, :util))
+          s.add_recurrence_rule IceCube::Rule.from_hash(rule.to_hash.reject{|k, v| [:by_set_pos, :count, :until].include? k})
         end
 
         occurrences = new_schedule.occurrences_between(start_of_month, end_of_month)

--- a/lib/ice_cube/validations/yearly_by_set_pos.rb
+++ b/lib/ice_cube/validations/yearly_by_set_pos.rb
@@ -4,7 +4,7 @@ module IceCube
     def by_set_pos(*by_set_pos)
       by_set_pos.flatten!
       by_set_pos.each do |set_pos|
-        unless (-366..366).include(set_pos) && set_pos != 0
+        unless (-366..366).cover?(set_pos) && set_pos != 0
           raise ArgumentError, "Expecting number in [-366, -1] or [1, 366], got #{set_pos} (#{by_set_pos})"
         end
       end

--- a/lib/ice_cube/validations/yearly_by_set_pos.rb
+++ b/lib/ice_cube/validations/yearly_by_set_pos.rb
@@ -1,0 +1,74 @@
+module IceCube
+  module Validations::YearlyBySetPos
+
+    def by_set_pos(*by_set_pos)
+      by_set_pos.flatten!
+      by_set_pos.each do |set_pos|
+        unless (-366..366).include(set_pos) && set_pos != 0
+          raise ArgumentError, "Expecting number in [-366, -1] or [1, 366], got #{set_pos} (#{by_set_pos})"
+        end
+      end
+
+      @by_set_pos = by_set_pos
+      replace_validations_for(:by_set_pos, [Validation.new(by_set_pos, self)])
+      self
+    end
+
+    class Validation
+
+      attr_reader :rule, :by_set_pos
+
+      def initialize(by_set_pos, rule)
+        @by_set_pos = by_set_pos
+        @rule = rule
+      end
+
+      def type
+        :day
+      end
+
+      def dst_adjust?
+        true
+      end
+
+      def validate(step_time, schedule)
+        start_of_year = step_time.beginning_of_year
+        end_of_year = step_time.end_of_year
+
+        new_schedule = IceCube::Schedule.new(step_time.last_year) do |s|
+          s.add_recurrence_rule IceCube::Rule.from_hash(rule.to_hash.except(:by_set_pos, :count, :util))
+        end
+
+        occurrences = new_schedule.occurrences_between(start_of_year, end_of_year)
+
+        index = occurrences.index(step_time)
+        if index.nil?
+          1
+        else
+          positive_set_pos = index + 1
+          negative_set_pos = index - occurrences.length
+
+          if @by_set_pos.include?(positive_set_pos) || @by_set_pos.include?(negative_set_pos)
+            0
+          else
+            1
+          end
+        end
+      end
+
+      def build_s(builder)
+        builder.piece(:by_set_pos) << by_set_pos
+      end
+
+      def build_hash(builder)
+        builder[:by_set_pos] = by_set_pos
+      end
+
+      def build_ical(builder)
+        builder['BYSETPOS'] << by_set_pos
+      end
+
+      nil
+    end
+  end
+end

--- a/lib/ice_cube/validations/yearly_by_set_pos.rb
+++ b/lib/ice_cube/validations/yearly_by_set_pos.rb
@@ -36,7 +36,7 @@ module IceCube
         end_of_year = step_time.end_of_year
 
         new_schedule = IceCube::Schedule.new(step_time.prev_year) do |s|
-          s.add_recurrence_rule IceCube::Rule.from_hash(rule.to_hash.except(:by_set_pos, :count, :util))
+          s.add_recurrence_rule IceCube::Rule.from_hash(rule.to_hash.reject{|k, v| [:by_set_pos, :count, :until].include? k})
         end
 
         occurrences = new_schedule.occurrences_between(start_of_year, end_of_year)

--- a/lib/ice_cube/validations/yearly_by_set_pos.rb
+++ b/lib/ice_cube/validations/yearly_by_set_pos.rb
@@ -35,7 +35,7 @@ module IceCube
         start_of_year = step_time.beginning_of_year
         end_of_year = step_time.end_of_year
 
-        new_schedule = IceCube::Schedule.new(step_time.last_year) do |s|
+        new_schedule = IceCube::Schedule.new(step_time.prev_year) do |s|
           s.add_recurrence_rule IceCube::Rule.from_hash(rule.to_hash.except(:by_set_pos, :count, :util))
         end
 

--- a/spec/examples/by_set_pos_spec.rb
+++ b/spec/examples/by_set_pos_spec.rb
@@ -1,0 +1,31 @@
+require File.dirname(__FILE__) + '/../spec_helper'
+
+module IceCube
+
+  describe MonthlyRule, 'BYSETPOS' do
+    it 'should behave correctly' do
+      schedule = IceCube::Schedule.from_ical "RRULE:FREQ=MONTHLY;COUNT=4;BYDAY=WE;BYSETPOS=4"
+      schedule.start_time = Time.new(2015, 5, 28, 12, 0, 0)
+      expect(schedule.occurrences_between(Time.new(2015, 01, 01), Time.new(2017, 01, 01)))
+        .to eq([
+                 Time.new(2015, 6, 24, 12, 0, 0),
+                 Time.new(2015, 7, 22, 12, 0, 0),
+                 Time.new(2015, 8, 26, 12, 0, 0),
+                 Time.new(2015, 9, 23, 12, 0, 0)
+               ])
+    end
+
+  end
+
+  describe YearlyRule, 'BYSETPOS' do
+    it 'should behave correctly' do
+      schedule = IceCube::Schedule.from_ical "RRULE:FREQ=YEARLY;BYMONTH=7;BYDAY=SU,MO,TU,WE,TH,FR,SA;BYSETPOS=-1"
+      schedule.start_time = Time.new(1966,7,5)
+      expect(schedule.occurrences_between(Time.new(2015, 01, 01), Time.new(2017, 01, 01)))
+        .to eq([
+                 Time.new(2015, 7, 31),
+                 Time.new(2016, 7, 31)
+               ])
+    end
+  end
+end

--- a/spec/examples/from_ical_spec.rb
+++ b/spec/examples/from_ical_spec.rb
@@ -86,6 +86,11 @@ module IceCube
       expect(rule).to eq(IceCube::Rule.weekly(2, :monday))
     end
 
+    it 'should be able to parse by_set_pos start (BYSETPOS)' do
+      rule = IceCube::Rule.from_ical("FREQ=MONTHLY;BYDAY=MO,WE;BYSETPOS=-1,1")
+      expect(rule).to eq(IceCube::Rule.monthly.day(:monday, :wednesday).by_set_pos([-1, 1]))
+    end
+
     it 'should return no occurrences after daily interval with count is over' do
       schedule = IceCube::Schedule.new(Time.now)
       schedule.add_recurrence_rule(IceCube::Rule.from_ical("FREQ=DAILY;COUNT=5"))


### PR DESCRIPTION
In August 2016, @NicolasMarlier added BYSETPOS support (https://github.com/seejohnrun/ice_cube/pull/349).

Then, in July 2018, @nehresma added a few small changes to run in modern Ruby and a more modern rspec (https://github.com/seejohnrun/ice_cube/pull/449).

Then, in January 2019, @davidstosik and @k3rni suggested changes to reduce complexity.

This incorporates all the above into a single diff.