### PR TITLE
[Bugfix] Weekly interval rules are sometimes calculated incorrectly

### DIFF
--- a/lib/ice_cube/validated_rule.rb
+++ b/lib/ice_cube/validated_rule.rb
@@ -48,10 +48,8 @@ module IceCube
     # to the given start time
     def next_time(time, start_time, closing_time)
       @time = time
-      unless @start_time
-        @start_time = realign(time, start_time)
-        @time = @start_time if @time < @start_time
-      end
+      @start_time ||= realign(time, start_time)
+      @time = @start_time if @time < @start_time
 
       return nil unless find_acceptable_time_before(closing_time)
 

--- a/lib/ice_cube/validations/hour_of_day.rb
+++ b/lib/ice_cube/validations/hour_of_day.rb
@@ -23,7 +23,7 @@ module IceCube
 
       first_hour = Array(validations[:hour_of_day]).min_by(&:value)
       time = TimeUtil::TimeWrapper.new(start_time, false)
-      if freq > 1
+      if freq > 1 && base_interval_validation.type == :hour
         offset = first_hour.validate(opening_time, start_time)
         time.add(:hour, offset - freq)
       else

--- a/spec/examples/weekly_rule_spec.rb
+++ b/spec/examples/weekly_rule_spec.rb
@@ -292,6 +292,19 @@ module IceCube
         expect(schedule.next_occurrence(sample[2] - 1)).to eq(sample[2])
       end
 
+      it 'should respect weekly intervals within narrow occurrence ranges' do
+        start_time = Time.utc(2020, 10, 27, 7, 0, 0)
+        schedule = Schedule.new(start_time, end_time: start_time + ONE_HOUR)
+        occurrence_start = Time.utc(2020, 11, 5, 0, 0, 0)
+        occurrence_end = Time.utc(2020, 11, 5, 23, 59, 59)
+
+        schedule.add_recurrence_rule IceCube::Rule.weekly(2).day(:thursday).hour_of_day(13)
+        schedule.add_recurrence_rule IceCube::Rule.weekly(1).day(:thursday).hour_of_day(12)
+        expect(schedule.occurrences_between(occurrence_start, occurrence_end)).to eq([
+          Time.utc(2020, 11, 5, 12, 0, 0)
+        ])
+      end
+
       it "should align next_occurrence with first valid weekday when schedule starts on a Wednesday" do
         t0 = Time.utc(2017,  6,  7)
         schedule = IceCube::Schedule.new(t0)

--- a/spec/examples/weekly_rule_spec.rb
+++ b/spec/examples/weekly_rule_spec.rb
@@ -338,6 +338,19 @@ module IceCube
           end
         end
       end
+
+      context 'when base interval validation type is not hourly' do
+        let(:start_time) { Time.utc(2018, 8, 7, 7, 0, 0) }
+        let(:end_time) { Time.utc(2018, 8, 7, 15, 0, 0) }
+        let(:biweekly) { IceCube::Rule.weekly(2).day(:saturday).hour_of_day(10) }
+        let(:schedule) { IceCube::Schedule.new(start_time, end_time: end_time) { |s| s.rrule biweekly } }
+        let(:range) { [Time.utc(2018, 8, 11, 7, 0, 0), Time.utc(2018, 8, 12, 6, 59, 59)] }
+        let(:expected_date) { Time.utc(2018, 8, 11, 10, 0, 0) }
+
+        it 'does not offset hour when base interval validation type is not hourly' do
+          expect(schedule.occurrences_between(range.first, range.last, spans: true)).to include expected_date
+        end
+      end
     end
 
     describe "using occurs_between with a weekly schedule" do


### PR DESCRIPTION
The spec covers the context through which this bug was uncovered. Essentially generating `occurrences_between` for a relatively small date range was yielding false occurrences for weekly interval rules.

I observed that `@time = @start_time if @time < @start_time` was set to happen only when `@start_time` was falsey. Iterations past the first for a given rule in `Schedule#next_time` [here](https://github.com/seejohnrun/ice_cube/blob/master/lib/ice_cube/schedule.rb#L451) in situations similar to the spec would pass in a `time` that was less than `start_time`.

Since `@start_time` was already defined in the rule, this `@time` value would be passed long for [validation](https://github.com/seejohnrun/ice_cube/blob/master/lib/ice_cube/validated_rule.rb#L147).

Most rules will then [return](https://github.com/seejohnrun/ice_cube/blob/master/lib/ice_cube/validations/weekly_interval.rb#L31) immediately in this case, not applying their validation.

Any feedback is welcome!