### PR TITLE
Add link to Lone Star Presentation on YouTube

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ schedule.add_recurrence_rule(
 ## Quick Introductions
 
 * [Presentation from Lone Star Ruby Conf – slides][ice_cube-lone_star_pdf]
-* [Presentation from Lone Star Ruby Conf – YouTube] (https://youtu.be/dOMW0WcvvRc)
+* [Presentation from Lone Star Ruby Conf – YouTube](https://youtu.be/dOMW0WcvvRc)
 * [Quick Introduction][ice_cube-ruby_nyc_pdf]
 * [Documentation Website][ice_cube-docs]
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ schedule.add_recurrence_rule(
 
 ## Quick Introductions
 
-* [Presentation from Lone Star Ruby Conf][ice_cube-lone_star_pdf]
+* [Presentation from Lone Star Ruby Conf – slides][ice_cube-lone_star_pdf]
+* [Presentation from Lone Star Ruby Conf – YouTube] (https://youtu.be/dOMW0WcvvRc)
 * [Quick Introduction][ice_cube-ruby_nyc_pdf]
 * [Documentation Website][ice_cube-docs]
 


### PR DESCRIPTION
I found the YouTube video in addition to the slides helpful.  It would be nice if the link was mentioned in the README.