### PR TITLE
Fix documentation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,5 +323,5 @@ Use the GitHub [issue tracker][ice_cube-issues]
 [travis-ice_cube-badge_image]: https://secure.travis-ci.org/seejohnrun/ice_cube.svg
 [ice_cube-lone_star_pdf]: http://seejohnrun.github.com/ice_cube/static/lsrc_ice_cube.pdf
 [ice_cube-ruby_nyc_pdf]: http://seejohnrun.github.com/ice_cube/static/ice_cube_ruby_nyc.pdf
-[ice_cube-docs]: http://seejohnrun.github.com/ice_cube/
+[ice_cube-docs]: http://seejohnrun.github.io/ice_cube/
 [ice_cube-issues]: https://github.com/seejohnrun/ice_cube/issues


### PR DESCRIPTION
Current link 404s since the docs website is not a repo, but rather github pages served out of github.io

Same fix needs to be made in the repo's metadata - thought I suspect that's through the UI, not code.
![repolink](https://user-images.githubusercontent.com/2740464/117752406-0d9b1480-b25a-11eb-9028-f33a5f511742.png)
