### PR TITLE
Fix `DEPRECATION WARNING: TimeWithZone#to_s(:short)`

### DIFF
--- a/lib/ice_cube/occurrence.rb
+++ b/lib/ice_cube/occurrence.rb
@@ -86,7 +86,7 @@ module IceCube
     #
     def to_s(format = nil)
       if format && to_time.public_method(:to_s).arity != 0
-        t0, t1 = start_time.to_s(format), end_time.to_s(format)
+        t0, t1 = start_time.to_formatted_s(format), end_time.to_formatted_s(format)
       else
         t0, t1 = start_time.to_s, end_time.to_s
       end

--- a/spec/examples/occurrence_spec.rb
+++ b/spec/examples/occurrence_spec.rb
@@ -28,7 +28,7 @@ describe Occurrence do
       time_now = Time.current
       occurrence = Occurrence.new(time_now)
 
-      expect(occurrence.to_s(:short)).to eq time_now.to_s(:short)
+      expect(occurrence.to_formatted_s(:short)).to eq time_now.to_formatted_s(:short)
     end
   end
 


### PR DESCRIPTION
Rails has deprecated passing a parameter to `to_s` and
now expects `to_formatted_s` to be used instead.

This is the full error I see:

    DEPRECATION WARNING: TimeWithZone#to_s(:short) is deprecated. Please use TimeWithZone#to_fs(:short) instead. (called from to_s at /ice-cube-ruby/ice_cube/lib/ice_cube/occurrence.rb:89)